### PR TITLE
fix(proxy): exclude _vercel paths + add missing CLAUDE.md files

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,56 @@
+# .github/CLAUDE.md
+
+## Composite Action
+
+Config: `.github/actions/setup/action.yml`
+
+Shared setup used by all CI jobs after checkout: Node (from `.nvmrc`), corepack enable, yarn cache restore, `yarn install --immutable`.
+
+Note: `actions/checkout` must remain in each job directly — local composite actions can only be resolved after the repo is checked out.
+
+Note: yarn caching is handled explicitly in the composite action (not via `actions/setup-node`'s built-in cache option, which is npm-only in v6). See `docs/adr/002-github-actions-yarn-cache.md` for details.
+
+## CI Workflow
+
+Config: `.github/workflows/ci.yml`
+
+Runs on push and pull request to `main`. Jobs:
+
+- **biome**, **knip**, **typecheck**, and **test** run in parallel on all events. **knip** detects unused files, exports, and dependencies; uses `--reporter github-actions` for inline PR annotations.
+- **build** runs after all four pass on all events — runs `vercel build`, then deploys to preview (on `pull_request`) or production (on push to `main`). Exposes `url` as a job output for downstream jobs.
+- **e2e** runs on `pull_request` only, after `build`. Runs Playwright tests against the Vercel preview URL via `PLAYWRIGHT_BASE_URL` (from the `build` job output) and `VERCEL_BYPASS_SECRET`. Installs Chromium only. Uploads `playwright-report/` as a CI artifact on every run.
+- **lighthouse** runs on `pull_request` only, after `build`. Audits the root `/` path against the Vercel preview URL using `treosh/lighthouse-ci-action`. Runs 2 audits and uploads artifacts. Thresholds defined in `lighthouserc.json`.
+
+Concurrency is configured to cancel in-progress runs on PRs when new commits are pushed. Runs on `main` are never cancelled.
+
+A top-level `permissions: contents: read` block restricts all jobs to read-only token access by default. The `build` job overrides this with `contents: read` + `deployments: write` for Vercel deployment.
+
+## Vercel Deployment
+
+The `build` job uses the Vercel CLI (`vercel` devDependency) with three required repository secrets:
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+Project IDs are sourced from `.vercel/project.json` (gitignored). Re-run `vercel link` locally to regenerate if needed.
+
+## Dependabot
+
+Config: `.github/dependabot.yml`
+
+Monitors `npm` dependencies weekly, targeting `main`. Commit messages use `chore(deps):` prefix via the `commit-message` config.
+
+## Dependabot Auto-merge
+
+Config: `.github/workflows/dependabot-auto-merge.yml`
+
+Triggers on `pull_request_target` (runs in base branch context so `GITHUB_TOKEN` has full permissions). Checks `github.actor == 'dependabot[bot]'` and enables auto-merge via squash. `pull_request_target` is safe here because no PR code is checked out or executed.
+
+## E2E Coverage Policy
+
+Any new user-facing feature must have a corresponding e2e spec added or updated before the PR is merged. Document the spec in the PR description's test plan section.
+
+## Notes
+
+- Node version is pinned via `.nvmrc` — update there to change it everywhere
+- Corepack must be enabled before running any `yarn` commands — handled in the composite action

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Requirements
+
+### Distributed Documentation Structure
+
+This repository **REQUIRES** distributed CLAUDE.md files throughout the directory tree. Each subdirectory with significant functionality must have its own CLAUDE.md file:
+
+- `.claude/CLAUDE.md` — Claude Code configuration and settings documentation
+- `.github/CLAUDE.md` — GitHub Actions workflow documentation
+- `e2e/CLAUDE.md` — e2e testing patterns and conventions
+
+**When adding new features or directories:**
+
+- Create separate CLAUDE.md files in relevant subdirectories
+- Do NOT expand this root CLAUDE.md file with detailed information
+- Keep this root file focused on high-level repository overview only
+- Distributed files keep context focused and only load relevant information when working in specific parts of the codebase
+
+**README.md vs CLAUDE.md distinction:**
+
+When a directory has a README.md, the CLAUDE.md should reference it. When a directory has both files:
+
+- **README.md** — User-facing documentation (what the component does, detailed explanations, setup instructions, architecture overview)
+- **CLAUDE.md** — Claude-specific development guidance (critical warnings, gotchas, common tasks with file:line references, testing patterns)
+- **Pattern**: CLAUDE.md should reference README.md for overview/details and focus only on what Claude needs to work safely and effectively
+
+### Documentation Maintenance
+
+When making code changes, you MUST proactively suggest updates to relevant documentation:
+
+- **CLAUDE.md files** — If you add/modify workflows, configuration files, or significant functionality, suggest updates to the relevant CLAUDE.md file in that directory
+  - Keep CLAUDE.md files concise (prefer pointers over content duplication)
+  - Avoid code snippets that will become outdated
+  - Use file:line references to point to authoritative sources
+  - Focus on high-level "what/why/how", not detailed descriptions
+- **README.md files** — If changes affect user-facing documentation or setup instructions, suggest updates to the relevant README.md file
+- **Proactive identification** — After completing code changes, explicitly check if documentation has become outdated and offer to update it
+
+Do not wait for the user to ask about documentation. Identify when your changes have made documentation stale and suggest specific updates.
+
+### Worktrees
+
+**REQUIRED**: All issue work MUST be done in a git worktree, not on the main working tree.
+
+Start a worktree session using Claude's built-in flag:
+
+```
+claude --worktree <issue-name>
+```
+
+This creates an isolated checkout at `.claude/worktrees/<issue-name>` on its own branch, so multiple issues can be worked in parallel without conflict. Claude will prompt to keep or clean up the worktree on exit.
+
+### Git Workflow
+
+All commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/) syntax:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
+
+**NEVER** commit with `--no-verify`. If a pre-commit hook fails, fix the underlying issue before committing. Bypassing hooks defeats the purpose of CI parity at commit time.
+
+**Commit message requirements:**
+
+- Keep messages brief and easy to parse — avoid lengthy descriptions
+- Focus on specific, scannable details that help humans quickly identify what a commit contains
+- **NEVER** add "🤖 Generated with Claude Code" or similar footers to commit messages
+- **NEVER** add "Co-Authored-By: Claude" or any co-author footers to commits
+
+**Pull request requirements:**
+
+- **NEVER** add "Co-Authored-By: Claude" or any co-author attribution to PR descriptions
+- **NEVER** add "🤖 Generated with Claude Code" or similar attribution to PRs
+- Keep PR descriptions focused on technical changes, testing, and references
+
+### File Operations and Repository Root
+
+**CRITICAL**: All file creation and modification operations MUST be relative to the git repository root.
+
+- Before creating files or directories, identify the repository root with `git rev-parse --show-toplevel`
+- NEVER create files outside the repository boundary — they will not be version controlled
+- Use `git status` to confirm new files will be tracked by git
+- If `git status` shows files as untracked, they are correctly within the repository
+- If files don't appear in `git status`, they are outside the repository boundary
+
+**Verification workflow:**
+
+1. Run `git rev-parse --show-toplevel` to identify repository root
+2. Create files/directories relative to that root
+3. Run `git status` to confirm files are detected by git
+
+### Architecture Decision Records (ADRs)
+
+ADRs are stored in `docs/adr/` and follow the naming convention `NNN-descriptive-slug.md`.
+
+**Template** (Status / Context / Decision / Consequences). Status values: `Proposed`, `Accepted`, `Deprecated`, `Superseded by ADR-NNN`.
+
+**PR checklist — for every pull request:**
+
+- **New ADR?** — If the PR introduces a significant architectural decision (new dependency, data flow pattern, tooling change, performance trade-off), create an ADR.
+- **Existing ADRs followed?** — Verify the changes comply with accepted ADRs. If a change conflicts, either revise the ADR first or explicitly note the deviation.
+- **Revise an ADR?** — If the constraints that drove a previous decision have changed, revisiting it is valid. Update the ADR's status to `Superseded by ADR-NNN` and write the replacement.
+
+### Yarn Install Warnings
+
+`yarn install` may produce warnings. All warnings MUST be resolved before closing any PR — investigate the cause and fix it (e.g. add or remove a `packageExtensions` entry in `.yarnrc.yml`, pin a transitive dependency, or update the offending package).
+
+### Technical Review Standards
+
+Always fully evaluate the technical merits of questions and suggestions against relevant sources of truth and documentation.
+
+**Do NOT** use validating phrases like "you're absolutely right" or similar affirmations. Instead:
+
+- Verify claims against actual code, configuration files, and documentation
+- Challenge suggestions when they conflict with established patterns or best practices
+- Provide objective, evidence-based responses
+- Respectfully disagree when warranted, citing specific technical reasons
+
+Technical accuracy and honest assessment are more valuable than agreement.

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -40,3 +40,15 @@ Use chained locators to scope queries to a subtree when multiple elements share 
 // Scope to a container to disambiguate — equivalent to Testing Library's within().
 await page.getByRole('dialog').getByRole('button', { name: 'Reset' }).click();
 ```
+
+## Dynamic Import Timing
+
+Components loaded via `next/dynamic` with `ssr: false` are absent from the initial server-rendered HTML. Do not assert on them immediately after navigation.
+
+Playwright's `expect` assertions auto-wait up to the configured timeout, so this is sufficient:
+
+```ts
+await expect(page.getByRole('button', { name: 'Some Action' })).toBeVisible();
+```
+
+No explicit `waitForSelector` or `waitFor` wrapper is needed.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -45,8 +45,9 @@ export const config = {
      * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
-     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+     * - _vercel (Vercel Analytics / Speed Insights beacons)
+     * - favicon.ico, sitemap.xml, robots.txt, manifest.webmanifest (metadata files)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|manifest.webmanifest).*)',
+    '/((?!api|_next/static|_next/image|_vercel|favicon.ico|sitemap.xml|robots.txt|manifest.webmanifest).*)',
   ],
 };


### PR DESCRIPTION
## Summary

- Adds `_vercel` to the proxy middleware matcher's negative-lookahead, fixing 404s on every `POST /_vercel/insights/view` and `/_vercel/speed-insights/vitals` beacon in production
- Ports all non-implementation-specific CLAUDE.md guidance from `brianespinosa/career` that was missing from this repo's bootstrap

## Changes

### `src/proxy.ts` — fixes #6
`/_vercel/*` requests were matching the proxy and being rewritten into the tenant tree (`/<branchHost>/_vercel/insights/view`), a route that doesn't exist. Vercel's built-in analytics handler was never reached.

### `CLAUDE.md` (new)
Root guidance document covering: Distributed Documentation Structure, Documentation Maintenance, Worktrees (REQUIRED for all issue work), Git Workflow (Conventional Commits, no `--no-verify`, no Claude attribution), File Operations, ADRs, Yarn Install Warnings, Technical Review Standards.

### `.github/CLAUDE.md` (new)
CI workflow documentation: composite setup action, job topology (biome/knip/typecheck/test → build → e2e + lighthouse), Vercel deployment setup, Dependabot and auto-merge configuration, e2e coverage policy.

### `e2e/CLAUDE.md`
Added Dynamic Import Timing section — guidance for asserting on components loaded via `next/dynamic` with `ssr: false`.

## Test plan

- [ ] CI passes (biome, knip, typecheck, test, build, e2e, lighthouse)
- [ ] After deploy: `POST /_vercel/insights/view` returns 2xx in Vercel runtime logs (verify via `mcp__vercel__get_runtime_logs` with `query='_vercel/insights'`)
- [ ] Tenant routing still works — branch hostnames resolve to correct rewrites