### PR TITLE
docs(claude): worktree dep workflow + yarn nmMode hardlinks-global

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,20 +14,11 @@ Tooling and infrastructure context for Claude sessions in this repo. For codebas
 
 ## Worktree workflow
 
-Worktrees live at `.claude/worktrees/<branch-name>/` and are created via `claude --worktree <name>` or `git worktree add`. They share a git object store with the root checkout but **do not** share installed dependencies. See ADR-004 (`docs/adr/004-yarn-hardlinks-global.md`) for the disk-dedup decision that underlies this workflow.
+Worktrees live at `.claude/worktrees/<branch-name>/` and are created via `claude --worktree <name>` or `git worktree add`. They share a git object store with the root checkout but **do not** share installed dependencies. See `docs/adr/004-yarn-hardlinks-global.md` for the disk-dedup decision that underlies this workflow.
 
 ### Installing dependencies per worktree
 
-Always run `yarn install` inside the worktree immediately after creation. **Never** symlink `node_modules/` back to the root checkout:
-
-```bash
-cd .claude/worktrees/<name>
-yarn install
-```
-
-Yarn Berry 4's global cache at `~/.yarn/berry/cache/` makes this cheap (typically 20–60s on this project): downloads are skipped, only the link step runs.
-
-If `claude --worktree` creates a symlinked `node_modules/` by default, delete it (`rm .claude/worktrees/<name>/node_modules`) before running `yarn install`.
+Always run `yarn install` inside the worktree immediately after creation. **Never** symlink `node_modules/` back to the root checkout. Yarn Berry 4's global cache at `~/.yarn/berry/cache/` makes per-worktree installs cheap (tens of seconds cache-warm): downloads are skipped, only the link step runs.
 
 A symlinked `node_modules/` silently breaks in several ways:
 
@@ -36,11 +27,9 @@ A symlinked `node_modules/` silently breaks in several ways:
 - Next.js file watchers follow the symlink and pick up changes written by another worktree's build.
 - `node_modules/.cache/` (Next, webpack, Biome, tsc) is shared — worktrees thrash each other's caches.
 
-### Disk dedup via `nmMode: hardlinks-global`
+### Disk dedup
 
-`.yarnrc.yml` sets `nmMode: hardlinks-global`. Each worktree's `node_modules/` hardlinks into a central content-addressed store under `~/.yarn/berry/`, so per-worktree disk cost is near-zero (inodes, not bytes) while each worktree keeps an independent dependency tree for lockfile purposes.
-
-Note this is the **global** variant, not `hardlinks-local`. `hardlinks-local` only dedupes duplicates within a single `node_modules/` — it does nothing cross-worktree.
+`.yarnrc.yml:16` sets `nmMode: hardlinks-global` so each worktree's `node_modules/` hardlinks into Yarn Berry's global store. See `docs/adr/004-yarn-hardlinks-global.md` for the rationale and the `hardlinks-local` rejection.
 
 ### Caveats to watch for
 
@@ -49,8 +38,6 @@ These scenarios are unlikely in this repo today but will cause problems if they 
 - **Shared inodes across worktrees.** Editing a file inside `node_modules/foo/` in one worktree mutates the same inode in every other worktree. If you need to experiment-patch a dependency, delete and reinstall that package's subtree to unshare first.
 - **`patch-package` incompatibility.** Tools that mutate `node_modules/` files directly collide with the global store. `yarn patch` (Berry-native) is safe — it writes to `.yarn/patches/`. Classic `patch-package` is dangerous; audit before adopting. This repo uses neither today.
 - **Cross-volume worktrees fall back to copying.** The global store lives under `~/.yarn/berry/`. A worktree on a different filesystem (external drive, NFS mount) silently degrades to copying. Not broken, just not optimized.
-- **`node_modules/.cache/` writes.** Next/webpack/Biome cache writers unlink-and-recreate, so hardlinked caches behave normally in practice. Verify on the first few `yarn dev` runs of a new worktree.
-- **Reverting is safe.** Remove `nmMode: hardlinks-global` from `.yarnrc.yml` and run `yarn install` in each tree — Berry rebuilds with copies, no corruption risk.
 
 ## Investigating production issues
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,46 @@ Tooling and infrastructure context for Claude sessions in this repo. For codebas
 - Destructive command permissions must **never** be added to `settings.json`. If a destructive action needs to be permitted, add it to `settings.local.json` only.
 - Permissions added to `settings.json` must be kept in alphabetical order.
 
+## Worktree workflow
+
+Worktrees live at `.claude/worktrees/<branch-name>/` and are created via `claude --worktree <name>` or `git worktree add`. They share a git object store with the root checkout but **do not** share installed dependencies. See ADR-004 (`docs/adr/004-yarn-hardlinks-global.md`) for the disk-dedup decision that underlies this workflow.
+
+### Installing dependencies per worktree
+
+Always run `yarn install` inside the worktree immediately after creation. **Never** symlink `node_modules/` back to the root checkout:
+
+```bash
+cd .claude/worktrees/<name>
+yarn install
+```
+
+Yarn Berry 4's global cache at `~/.yarn/berry/cache/` makes this cheap (typically 20–60s on this project): downloads are skipped, only the link step runs.
+
+If `claude --worktree` creates a symlinked `node_modules/` by default, delete it (`rm .claude/worktrees/<name>/node_modules`) before running `yarn install`.
+
+A symlinked `node_modules/` silently breaks in several ways:
+
+- A branch that adds/removes a dependency mutates the **root's** tree — the root's lockfile and `node_modules/` disagree.
+- Two worktrees running `yarn install` concurrently race on the same `install-state.gz` and corrupt state.
+- Next.js file watchers follow the symlink and pick up changes written by another worktree's build.
+- `node_modules/.cache/` (Next, webpack, Biome, tsc) is shared — worktrees thrash each other's caches.
+
+### Disk dedup via `nmMode: hardlinks-global`
+
+`.yarnrc.yml` sets `nmMode: hardlinks-global`. Each worktree's `node_modules/` hardlinks into a central content-addressed store under `~/.yarn/berry/`, so per-worktree disk cost is near-zero (inodes, not bytes) while each worktree keeps an independent dependency tree for lockfile purposes.
+
+Note this is the **global** variant, not `hardlinks-local`. `hardlinks-local` only dedupes duplicates within a single `node_modules/` — it does nothing cross-worktree.
+
+### Caveats to watch for
+
+These scenarios are unlikely in this repo today but will cause problems if they come up:
+
+- **Shared inodes across worktrees.** Editing a file inside `node_modules/foo/` in one worktree mutates the same inode in every other worktree. If you need to experiment-patch a dependency, delete and reinstall that package's subtree to unshare first.
+- **`patch-package` incompatibility.** Tools that mutate `node_modules/` files directly collide with the global store. `yarn patch` (Berry-native) is safe — it writes to `.yarn/patches/`. Classic `patch-package` is dangerous; audit before adopting. This repo uses neither today.
+- **Cross-volume worktrees fall back to copying.** The global store lives under `~/.yarn/berry/`. A worktree on a different filesystem (external drive, NFS mount) silently degrades to copying. Not broken, just not optimized.
+- **`node_modules/.cache/` writes.** Next/webpack/Biome cache writers unlink-and-recreate, so hardlinked caches behave normally in practice. Verify on the first few `yarn dev` runs of a new worktree.
+- **Reverting is safe.** Remove `nmMode: hardlinks-global` from `.yarnrc.yml` and run `yarn install` in each tree — Berry rebuilds with copies, no corruption risk.
+
 ## Investigating production issues
 
 Prefer real runtime data over inferring from source. The **Vercel MCP** (`mcp__vercel__*` tools) is the canonical source of truth for deployed state:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,6 +13,7 @@ logFilters:
     pattern: "*react-textfit*"
 
 nodeLinker: node-modules
+nmMode: hardlinks-global
 
 packageExtensions:
   "@napi-rs/wasm-runtime@*":

--- a/docs/adr/004-yarn-hardlinks-global.md
+++ b/docs/adr/004-yarn-hardlinks-global.md
@@ -1,0 +1,39 @@
+# ADR-004: Yarn Berry `nmMode: hardlinks-global` for cross-worktree `node_modules/` dedup
+
+## Status
+
+Accepted
+
+## Context
+
+The root `CLAUDE.md` mandates worktrees for all issue work (`.claude/worktrees/<branch-name>/`), and worktrees must not share a `node_modules/` with the root checkout — a symlinked `node_modules/` silently breaks when a branch mutates dependencies, races on `install-state.gz`, pollutes Next.js file watchers, and thrashes shared `node_modules/.cache/` across trees.
+
+An independent install per worktree solves those failure modes but costs ~500MB of disk per worktree at current dependency scale. Running three or four worktrees simultaneously is routine enough that paying ~2GB for parallelism is worth avoiding.
+
+Yarn Berry 4 (already in use — `packageManager: yarn@4.13.0`, `nodeLinker: node-modules`) offers `nmMode: hardlinks-global`: each `node_modules/` is hardlinked from a central content-addressed store under `~/.yarn/berry/`. Per-worktree disk cost drops to near-zero (extra inodes, not bytes), while each tree keeps an independent dependency graph for lockfile purposes.
+
+The alternative setting `hardlinks-local` only dedupes duplicate packages within a single `node_modules/` tree and does nothing for the cross-worktree case this repo actually faces. PnP (`nodeLinker: pnp`) would also solve it, but Next.js 16 + PnP has known rough edges and the migration cost isn't warranted just for worktree ergonomics.
+
+Material caveats exist but are unlikely to bite this repo today:
+
+- `patch-package` mutates `node_modules/` files in place and would collide with the hardlinked global store. The repo has no `patch-package` dependency and no `patches/` directory. `yarn patch` (Berry-native) is unaffected — it writes to `.yarn/patches/`.
+- Editing a file inside one worktree's `node_modules/` mutates the inode shared with every other worktree. Unusual in normal development; noted in `.claude/CLAUDE.md` for anyone who does reach for an in-place `node_modules/` edit.
+- Worktrees on a different filesystem from `~/.yarn/berry/` fall back to copying silently — correct, just not optimized.
+- No CI impact: CI's `~/.yarn/berry/` is empty at the start of every run, so `nmMode: hardlinks-global` is a no-op there.
+
+## Decision
+
+1. Set `nmMode: hardlinks-global` in `.yarnrc.yml`, adjacent to the existing `nodeLinker: node-modules`.
+2. Keep `nodeLinker: node-modules` — no PnP migration.
+3. Document the workflow and caveats in `.claude/CLAUDE.md` under a new "Worktree workflow" section, so anyone about to hit a caveat scenario has the context to understand why.
+4. Require `yarn install` per worktree (never a symlink back to the root); covered in the same `.claude/CLAUDE.md` section.
+
+## Consequences
+
+- **Disk**: marginal cost of each additional worktree's `node_modules/` is near-zero. N worktrees ≈ the size of one, not N × 500MB.
+- **Install time**: unchanged for the first install on a cold cache. Subsequent worktrees link from the global store and complete in tens of seconds (`20–60s` observed on this project).
+- **Independence preserved**: each worktree has its own lockfile state and its own `node_modules/` tree. A dependency change in one worktree does not leak into another.
+- **`patch-package` becomes a latent blocker**: if the repo ever adopts `patch-package`, this ADR must be revisited (either supersede, or switch that workflow to `yarn patch`).
+- **In-place `node_modules/` edits propagate**: a behavioral change worth knowing about; documented in `.claude/CLAUDE.md`. Delete-and-reinstall unshares the subtree.
+- **Reverting is cheap**: remove the `nmMode` line from `.yarnrc.yml` and run `yarn install` in each tree. Berry rebuilds with copies; no corruption risk.
+- **CI**: no change. The setting is a no-op against an empty Berry store.

--- a/docs/adr/004-yarn-hardlinks-global.md
+++ b/docs/adr/004-yarn-hardlinks-global.md
@@ -17,7 +17,7 @@ The alternative setting `hardlinks-local` only dedupes duplicate packages within
 Material caveats exist but are unlikely to bite this repo today:
 
 - `patch-package` mutates `node_modules/` files in place and would collide with the hardlinked global store. The repo has no `patch-package` dependency and no `patches/` directory. `yarn patch` (Berry-native) is unaffected — it writes to `.yarn/patches/`.
-- Editing a file inside one worktree's `node_modules/` mutates the inode shared with every other worktree. Unusual in normal development; noted in `.claude/CLAUDE.md` for anyone who does reach for an in-place `node_modules/` edit.
+- Editing a file inside one worktree's `node_modules/` mutates the inode shared with every other worktree. Unusual in normal development; noted in the `Worktree workflow` section of `.claude/CLAUDE.md` for anyone who does reach for an in-place `node_modules/` edit.
 - Worktrees on a different filesystem from `~/.yarn/berry/` fall back to copying silently — correct, just not optimized.
 - No CI impact: CI's `~/.yarn/berry/` is empty at the start of every run, so `nmMode: hardlinks-global` is a no-op there.
 
@@ -31,9 +31,9 @@ Material caveats exist but are unlikely to bite this repo today:
 ## Consequences
 
 - **Disk**: marginal cost of each additional worktree's `node_modules/` is near-zero. N worktrees ≈ the size of one, not N × 500MB.
-- **Install time**: unchanged for the first install on a cold cache. Subsequent worktrees link from the global store and complete in tens of seconds (`20–60s` observed on this project).
+- **Install time**: unchanged for the first install on a cold cache. Subsequent worktrees link from the global store and complete in tens of seconds.
 - **Independence preserved**: each worktree has its own lockfile state and its own `node_modules/` tree. A dependency change in one worktree does not leak into another.
 - **`patch-package` becomes a latent blocker**: if the repo ever adopts `patch-package`, this ADR must be revisited (either supersede, or switch that workflow to `yarn patch`).
-- **In-place `node_modules/` edits propagate**: a behavioral change worth knowing about; documented in `.claude/CLAUDE.md`. Delete-and-reinstall unshares the subtree.
+- **In-place `node_modules/` edits propagate**: a behavioral change worth knowing about; documented in the `Worktree workflow` section of `.claude/CLAUDE.md`. Delete-and-reinstall unshares the subtree.
 - **Reverting is cheap**: remove the `nmMode` line from `.yarnrc.yml` and run `yarn install` in each tree. Berry rebuilds with copies; no corruption risk.
 - **CI**: no change. The setting is a no-op against an empty Berry store.


### PR DESCRIPTION
## Summary

Establishes per-worktree `yarn install` as the documented norm (no more symlinked `node_modules/`) and enables `nmMode: hardlinks-global` so worktree `node_modules/` trees hardlink into Yarn Berry's global store — near-zero marginal disk cost per worktree while each tree keeps an independent dependency graph.

Combines the two PRs outlined in #14:

- Docs: new "Worktree workflow" section in `.claude/CLAUDE.md` covering install, disk dedup, and caveats.
- Config: `nmMode: hardlinks-global` in `.yarnrc.yml`.
- ADR-004 captures the tooling/perf trade-off per ADR-001's PR checklist.

## Caveats documented inline

These scenarios are unlikely in this repo today but would invalidate the decision, so they're named in `.claude/CLAUDE.md`:

- Shared inodes across worktrees when editing `node_modules/` in place.
- `patch-package` incompatibility with the hardlinked global store (`yarn patch` is safe).
- Cross-volume worktrees silently fall back to copying.
- `node_modules/.cache/` write semantics (cache writers unlink-and-recreate — no real risk).
- Reverting is safe: drop the `nmMode` line and reinstall.

## Test plan

- [x] `yarn install` in fresh worktree with `nmMode: hardlinks-global` — 36s, cache-warm.
- [x] `yarn typecheck` — pass.
- [x] `yarn test` — pass.
- [x] `yarn build` — pass.
- [x] Two-worktree inode verification: `react/package.json` shares inode `691242672` with `links=3` (Berry store + issue-14 + verify-b) — confirms cross-worktree hardlink dedup.
- [ ] `yarn e2e` — not run locally; CI will validate.
- [ ] CI parity — `nmMode` is a no-op against a cold `~/.yarn/berry/`, so no CI regression expected.

Closes #14.