### PR TITLE
refactor(tenant): extract shared resolveTenantFromHeaders helper

### DIFF
--- a/src/app/icon.spec.tsx
+++ b/src/app/icon.spec.tsx
@@ -7,6 +7,11 @@ import Icon from './icon';
 import { ICON_SIZES } from './icon-sizes';
 
 vi.mock('next/headers');
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
 
 const mockHost = (host: string) =>
   vi.mocked(headers).mockResolvedValue({

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,12 +1,9 @@
-import { headers } from 'next/headers';
 import { ImageResponse } from 'next/og';
 
-import { branchData, branchLogo, branchLogoSrc } from '@/data';
+import { branchLogo, branchLogoSrc } from '@/data';
+import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders';
 
 import { ICON_SIZES } from './icon-sizes';
-
-const DOMAINS = Object.keys(branchData);
-const PREVIEW_FALLBACK = DOMAINS[0];
 
 export function generateImageMetadata() {
   return ICON_SIZES.map((size) => ({
@@ -17,13 +14,10 @@ export function generateImageMetadata() {
 }
 
 export default async function Icon({ id }: { id: Promise<string> | string }) {
-  const host = (await headers()).get('host') ?? '';
-  const isLocal = host.startsWith('localhost');
-  const domain = isLocal
-    ? 'tacomagooners.com'
-    : host in branchData
-      ? host
-      : PREVIEW_FALLBACK;
+  const domain = await resolveTenantFromHeaders({
+    caller: 'icon',
+    strict: true,
+  });
 
   const Logo = branchLogo[domain];
   const rasterSrc = branchLogoSrc[domain];

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,34 +1,15 @@
 import type { MetadataRoute } from 'next';
-import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
 
 import { branchData } from '@/data';
+import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders';
 
 import { ICON_SIZES } from './icon-sizes';
 
-const DOMAINS = Object.keys(branchData);
-const PREVIEW_FALLBACK = DOMAINS[0];
-
 export default async function Manifest(): Promise<MetadataRoute.Manifest> {
-  const headersList = await headers();
-  const domain = headersList.get('host') || 'localhost';
-
-  const isLocal = domain.startsWith('localhost');
-  const isKnown = domain in branchData;
-
-  let branchSite: string;
-  if (isLocal) {
-    branchSite = 'tacomagooners.com';
-  } else if (isKnown) {
-    branchSite = domain;
-  } else if (process.env.VERCEL_ENV !== 'production') {
-    // dev / preview — safe to fall back so previews are usable
-    branchSite = PREVIEW_FALLBACK;
-  } else {
-    // Production with unknown host — do NOT silently impersonate a branch
-    console.warn(`[manifest] unknown host in production: ${domain}`);
-    notFound();
-  }
+  const branchSite = await resolveTenantFromHeaders({
+    caller: 'manifest',
+    strict: true,
+  });
 
   const branch = branchData[branchSite];
 

--- a/src/app/opengraph-image.spec.tsx
+++ b/src/app/opengraph-image.spec.tsx
@@ -6,6 +6,11 @@ import { branchData } from '@/data';
 import Image from './opengraph-image';
 
 vi.mock('next/headers');
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
 
 const mockHost = (host: string) =>
   vi.mocked(headers).mockResolvedValue({

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,10 +1,7 @@
-import { headers } from 'next/headers';
 import { ImageResponse } from 'next/og';
 
-import { branchData, branchLogo, branchLogoSrc } from '@/data';
-
-const DOMAINS = Object.keys(branchData);
-const PREVIEW_FALLBACK = DOMAINS[0];
+import { branchLogo, branchLogoSrc } from '@/data';
+import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders';
 
 export const size = {
   width: 1200,
@@ -13,13 +10,10 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const host = (await headers()).get('host') ?? '';
-  const isLocal = host.startsWith('localhost');
-  const domain = isLocal
-    ? 'tacomagooners.com'
-    : host in branchData
-      ? host
-      : PREVIEW_FALLBACK;
+  const domain = await resolveTenantFromHeaders({
+    caller: 'opengraph-image',
+    strict: true,
+  });
 
   const Logo = branchLogo[domain];
   const rasterSrc = branchLogoSrc[domain];

--- a/src/lib/tenant/CLAUDE.md
+++ b/src/lib/tenant/CLAUDE.md
@@ -1,0 +1,15 @@
+# src/lib/tenant/ — Tenant Resolution
+
+Shared helpers for resolving which branch site (tenant) a request belongs to.
+
+## Key file
+
+- `resolveTenantFromHeaders.ts` — reads the `Host` header and maps it to a known branch domain. Supports `strict` mode (warns + 404 for unknown production hosts) vs non-strict (falls back to `PREVIEW_FALLBACK`).
+
+## Callers
+
+Used by the three metadata routes: `src/app/manifest.ts`, `src/app/opengraph-image.tsx`, `src/app/icon.tsx`. All call with `strict: true`.
+
+## Testing
+
+Tests in `resolveTenantFromHeaders.spec.ts` mock `next/headers` and `next/navigation`. The global `vitest.setup.ts` throws on unexpected `console.warn`, so the strict-production test must explicitly mock `console.warn`.

--- a/src/lib/tenant/resolveTenantFromHeaders.spec.ts
+++ b/src/lib/tenant/resolveTenantFromHeaders.spec.ts
@@ -1,0 +1,88 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveTenantFromHeaders } from './resolveTenantFromHeaders';
+
+vi.mock('next/headers');
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+const mockHost = (host: string | null) =>
+  vi.mocked(headers).mockResolvedValue({
+    get: () => host,
+  } as unknown as Awaited<ReturnType<typeof headers>>);
+
+describe('resolveTenantFromHeaders', () => {
+  const originalEnv = process.env.VERCEL_ENV;
+
+  afterEach(() => {
+    process.env.VERCEL_ENV = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('treats a null host header as localhost', async () => {
+    mockHost(null);
+    const domain = await resolveTenantFromHeaders({
+      caller: 'test',
+      strict: true,
+    });
+    expect(domain).toBe('tacomagooners.com');
+  });
+
+  it('resolves localhost to tacomagooners.com', async () => {
+    mockHost('localhost:3000');
+    const domain = await resolveTenantFromHeaders({
+      caller: 'test',
+      strict: true,
+    });
+    expect(domain).toBe('tacomagooners.com');
+  });
+
+  it('resolves a known host to itself', async () => {
+    mockHost('pdxgooners.com');
+    const domain = await resolveTenantFromHeaders({
+      caller: 'test',
+      strict: true,
+    });
+    expect(domain).toBe('pdxgooners.com');
+  });
+
+  it('falls back to PREVIEW_FALLBACK for unknown host on preview', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    mockHost('app-git-foo-arsenalamerica.vercel.app');
+    const domain = await resolveTenantFromHeaders({
+      caller: 'test',
+      strict: true,
+    });
+    expect(domain).toBe('boisegooners.com');
+  });
+
+  it('calls notFound() and warns for unknown host in production (strict)', async () => {
+    process.env.VERCEL_ENV = 'production';
+    mockHost('bad.example');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      resolveTenantFromHeaders({ caller: 'test-caller', strict: true }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+
+    expect(notFound).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      '[test-caller] unknown host in production: bad.example',
+    );
+  });
+
+  it('falls back to PREVIEW_FALLBACK for unknown host in production (non-strict)', async () => {
+    process.env.VERCEL_ENV = 'production';
+    mockHost('bad.example');
+    const domain = await resolveTenantFromHeaders({
+      caller: 'test',
+      strict: false,
+    });
+    expect(domain).toBe('boisegooners.com');
+  });
+});

--- a/src/lib/tenant/resolveTenantFromHeaders.ts
+++ b/src/lib/tenant/resolveTenantFromHeaders.ts
@@ -1,0 +1,38 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+
+import { branchData } from '@/data';
+
+/** First domain in branchData — used as the fallback on preview/dev. */
+export const PREVIEW_FALLBACK = Object.keys(branchData)[0];
+
+const LOCAL_FALLBACK = 'tacomagooners.com';
+
+interface ResolveTenantOptions {
+  /** Identifier for log messages, e.g. 'manifest', 'icon'. */
+  caller: string;
+  /**
+   * When true and the host is unknown in production,
+   * logs a warning and calls notFound().
+   * When false, falls back to PREVIEW_FALLBACK regardless of environment.
+   */
+  strict: boolean;
+}
+
+export async function resolveTenantFromHeaders({
+  caller,
+  strict,
+}: ResolveTenantOptions): Promise<string> {
+  const headersList = await headers();
+  const host = headersList.get('host') || 'localhost';
+
+  if (host.startsWith('localhost')) return LOCAL_FALLBACK;
+  if (host in branchData) return host;
+
+  if (strict && process.env.VERCEL_ENV === 'production') {
+    console.warn(`[${caller}] unknown host in production: ${host}`);
+    return notFound();
+  }
+
+  return PREVIEW_FALLBACK;
+}


### PR DESCRIPTION
## Summary

- Extracts three divergent inline `Host`-header tenant resolution implementations into a single `resolveTenantFromHeaders` helper at `src/lib/tenant/resolveTenantFromHeaders.ts`
- Fixes production bug where `icon.tsx` and `opengraph-image.tsx` silently fell back to `PREVIEW_FALLBACK` for unknown hosts in production instead of calling `notFound()`
- Adds 6 unit tests for the helper covering all resolution paths (localhost, known host, unknown preview, unknown production strict/non-strict, null host header)

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test` passes (122 tests, 100% coverage on helper)
- [x] `yarn build` succeeds
- [x] `yarn check` (Biome) clean

Closes #29