### PR TITLE
fix(data): throw on fetch failure + add error.tsx boundaries per segment

### DIFF
--- a/src/app/[domain]/error.tsx
+++ b/src/app/[domain]/error.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import { RouteError } from '@/components';
+
+export default RouteError;

--- a/src/app/[domain]/fixtures/error.tsx
+++ b/src/app/[domain]/fixtures/error.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import { RouteError } from '@/components';
+
+export default RouteError;

--- a/src/app/[domain]/game-card/error.tsx
+++ b/src/app/[domain]/game-card/error.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import { RouteError } from '@/components';
+
+export default RouteError;

--- a/src/app/[domain]/page.tsx
+++ b/src/app/[domain]/page.tsx
@@ -14,7 +14,6 @@ export default async function Home(props: {
   const branch = branchData[params.domain];
   const Logo = branchLogo[branch.domain];
 
-  // TODO: Move this into the fixture card itself or the suspense boundary will never catch an issue (500 returns an object not an array)
   const [nextFixture] = await getNextFixture();
 
   return (

--- a/src/app/[domain]/table/error.tsx
+++ b/src/app/[domain]/table/error.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import { RouteError } from '@/components';
+
+export default RouteError;

--- a/src/components/RouteError/RouteError.module.scss
+++ b/src/components/RouteError/RouteError.module.scss
@@ -1,0 +1,35 @@
+._ {
+  padding: 2rem;
+  border-radius: 1.5em;
+  margin: 2em 0;
+  background-color: rgb(0 0 0 / 10%);
+  text-align: center;
+
+  h2 {
+    position: static;
+    margin-bottom: 0.5em;
+    font-family: ars-bold, sans-serif;
+    text-transform: uppercase;
+  }
+
+  p {
+    margin: 1em 0;
+    opacity: 0.8;
+  }
+
+  button {
+    padding: 0.75em 1.5em;
+    border: 2px solid #fff;
+    border-radius: 0.5em;
+    background: transparent;
+    color: #fff;
+    cursor: pointer;
+    font-family: ars-bold, sans-serif;
+    font-size: 1em;
+    text-transform: uppercase;
+
+    &:hover {
+      background-color: rgb(255 255 255 / 15%);
+    }
+  }
+}

--- a/src/components/RouteError/RouteError.tsx
+++ b/src/components/RouteError/RouteError.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import styles from './RouteError.module.scss';
+
+export interface RouteErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export function RouteError({ reset }: RouteErrorProps) {
+  return (
+    <div className={styles._}>
+      <h2>Something went wrong</h2>
+      <p>An unexpected error occurred.</p>
+      <button type='button' onClick={reset}>
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,5 +10,6 @@ export * from './Main/Main';
 export * from './NavBar/NavBar';
 export * from './NextGame/NextGame';
 export * from './PWAInstallPrompt/PWAInstallPrompt';
+export * from './RouteError/RouteError';
 export * from './SocialLinks/SocialLinks';
 export * from './TeamLogo/TeamLogo';

--- a/src/lib/data/fixtures.ts
+++ b/src/lib/data/fixtures.ts
@@ -1,5 +1,4 @@
 import { type FixtureEntity, smFixtures, smTvStation } from '@/lib/sportmonks';
-import { season } from '@/lib/utils';
 
 const USA_COUNTRY_ID = 3483;
 
@@ -36,13 +35,7 @@ export async function getFixtures(): Promise<FixtureEntity[]> {
     return all;
   } catch (error) {
     console.error(error);
-    return [
-      {
-        season,
-        status: 500,
-        error,
-      },
-    ] as unknown as FixtureEntity[];
+    throw error;
   }
 }
 
@@ -83,12 +76,6 @@ export async function getNextFixture(): Promise<FixtureEntity[]> {
     return data;
   } catch (error) {
     console.error(error);
-    return [
-      {
-        season,
-        status: 500,
-        error,
-      },
-    ] as unknown as FixtureEntity[];
+    throw error;
   }
 }

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -22,9 +22,6 @@ export async function getStandings(): Promise<StandingEntity[]> {
     return cleanData as unknown as StandingEntity[];
   } catch (error) {
     console.error(error);
-    return {
-      status: 500,
-      error,
-    } as unknown as StandingEntity[];
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary

- Replace error-as-value sentinel returns (`as unknown as T[]`) in `getFixtures`, `getNextFixture`, and `getStandings` with `throw` so Next.js error boundaries catch failures
- Add a shared `RouteError` client component with branded error card + retry button
- Add `error.tsx` at `[domain]/`, `fixtures/`, `table/`, and `game-card/` route segments so fetch failures render a graceful boundary instead of crashing the page
- Remove stale TODO comment from `[domain]/page.tsx`
- Remove unused `season` import from `fixtures.ts`

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test` — 122 tests pass
- [x] `yarn knip` — clean
- [x] `yarn build` — all routes compile
- [x] `yarn check` (biome) — clean
- [ ] Manual: invalidate Sportmonks API key, confirm error boundary renders at each route with retry button

Closes #31