### PR TITLE
docs: add README with CI badge and repo description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# app
+
+[![CI](https://github.com/arsenalamerica/app/actions/workflows/ci.yml/badge.svg)](https://github.com/arsenalamerica/app/actions/workflows/ci.yml)
+
+> Arsenal America branch apps


### PR DESCRIPTION
## Summary
- Add README.md with project title, CI badge, and repo description
- Follows the same pattern as brianespinosa/career