### PR TITLE
feat(standings): auto-resolve season ID via cron-synced config

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -46,6 +46,23 @@ Config: `.github/workflows/dependabot-auto-merge.yml`
 
 Triggers on `pull_request_target` (runs in base branch context so `GITHUB_TOKEN` has full permissions). Checks `github.actor == 'dependabot[bot]'` and enables auto-merge via squash. `pull_request_target` is safe here because no PR code is checked out or executed.
 
+## Sync Seasons Workflow
+
+Config: `.github/workflows/sync-seasons.yml`
+
+Monthly cron (1st of the month at noon UTC) + manual `workflow_dispatch`. Runs `scripts/sync-seasons.mjs` to fetch the current Premier League season ID from Sportmonks and update `src/lib/sportmonks/seasons.json`. If the season ID changed, force-pushes a `chore/sync-seasons` branch and creates a PR (or updates the existing one) via the GitHub App token.
+
+Does **not** use the composite setup action — the script only needs Node.js, not `yarn install`.
+
+Idempotent: re-running on the same day force-pushes the branch and reuses the existing PR.
+
+Required secrets (in addition to those listed in Vercel Deployment):
+- `MONK_TOKEN` — Sportmonks API token
+- `APP_ID` — GitHub App ID for automated PR creation
+- `APP_PK` — GitHub App private key
+
+The GitHub App token is used instead of `GITHUB_TOKEN` so the resulting PR triggers CI workflows. See `actions/create-github-app-token@v2`.
+
 ## E2E Coverage Policy
 
 Any new user-facing feature must have a corresponding e2e spec added or updated before the PR is merged. Document the spec in the PR description's test plan section.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -61,7 +61,7 @@ Required secrets (in addition to those listed in Vercel Deployment):
 - `APP_ID` — GitHub App ID for automated PR creation
 - `APP_PK` — GitHub App private key
 
-The GitHub App token is used instead of `GITHUB_TOKEN` so the resulting PR triggers CI workflows. See `actions/create-github-app-token@v2`.
+The `gunnersaurus-bot` GitHub App token is used instead of `GITHUB_TOKEN` so the resulting PR triggers CI workflows. See `actions/create-github-app-token@v2`. Commits are attributed to `gunnersaurus-bot[bot]`.
 
 ## E2E Coverage Policy
 

--- a/.github/workflows/sync-seasons.yml
+++ b/.github/workflows/sync-seasons.yml
@@ -50,6 +50,16 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_BODY: |
+            ## Summary
+
+            - Automated update of `src/lib/sportmonks/seasons.json` with the current Premier League season ID from Sportmonks
+
+            ## Test plan
+
+            - [ ] `yarn typecheck` passes
+            - [ ] `yarn build` passes
+            - [ ] Standings table renders correctly on preview deployment
         run: |
           BRANCH="chore/sync-seasons"
           git config user.name "github-actions[bot]"
@@ -61,16 +71,5 @@ jobs:
           if ! gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
             gh pr create \
               --title "chore(data): sync Premier League season ID" \
-              --body "$(cat <<'EOF'
-## Summary
-
-- Automated update of `src/lib/sportmonks/seasons.json` with the current Premier League season ID from Sportmonks
-
-## Test plan
-
-- [ ] `yarn typecheck` passes
-- [ ] `yarn build` passes
-- [ ] Standings table renders correctly on preview deployment
-EOF
-            )"
+              --body "$PR_BODY"
           fi

--- a/.github/workflows/sync-seasons.yml
+++ b/.github/workflows/sync-seasons.yml
@@ -1,0 +1,76 @@
+name: Sync Seasons
+
+on:
+  schedule:
+    - cron: '0 12 1 * *' # 1st of every month at noon UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PK }}
+
+      - uses: actions/checkout@v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.2.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Sync season data from Sportmonks
+        env:
+          MONK_TOKEN: ${{ secrets.MONK_TOKEN }}
+        run: node scripts/sync-seasons.mjs
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet src/lib/sportmonks/seasons.json; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create or update pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="chore/sync-seasons"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add src/lib/sportmonks/seasons.json
+          git commit -m "chore(data): sync Premier League season ID from Sportmonks"
+          git push --force origin "$BRANCH"
+          if ! gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
+            gh pr create \
+              --title "chore(data): sync Premier League season ID" \
+              --body "$(cat <<'EOF'
+## Summary
+
+- Automated update of `src/lib/sportmonks/seasons.json` with the current Premier League season ID from Sportmonks
+
+## Test plan
+
+- [ ] `yarn typecheck` passes
+- [ ] `yarn build` passes
+- [ ] Standings table renders correctly on preview deployment
+EOF
+            )"
+          fi

--- a/.github/workflows/sync-seasons.yml
+++ b/.github/workflows/sync-seasons.yml
@@ -62,8 +62,8 @@ jobs:
             - [ ] Standings table renders correctly on preview deployment
         run: |
           BRANCH="chore/sync-seasons"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "gunnersaurus-bot[bot]"
+          git config user.email "276655943+gunnersaurus-bot[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add src/lib/sportmonks/seasons.json
           git commit -m "chore(data): sync Premier League season ID from Sportmonks"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e": "playwright test",
     "knip": "knip",
     "start": "next start",
+    "sync:seasons": "node scripts/sync-seasons.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,13 @@
+# scripts/
+
+Standalone Node.js scripts for scheduled data syncing. Run via `yarn sync:*` or from GitHub Actions cron workflows.
+
+## sync-seasons.mjs
+
+Fetches the current Premier League season ID from the Sportmonks `/leagues/{id}` endpoint and updates `src/lib/sportmonks/seasons.json`. Requires `MONK_TOKEN` env var.
+
+- Run locally: `MONK_TOKEN=<token> yarn sync:seasons`
+- Automated: `.github/workflows/sync-seasons.yml` (monthly cron)
+- Exits 0 whether or not the file changed; non-zero on API errors
+
+Uses native Node.js `fetch` and `fs/promises` — no extra dependencies.

--- a/scripts/sync-seasons.mjs
+++ b/scripts/sync-seasons.mjs
@@ -1,0 +1,57 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SPORTMONKS_BASE = 'https://api.sportmonks.com/v3/football';
+const PREMIER_LEAGUE_ID = 8;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const seasonsPath = resolve(__dirname, '../src/lib/sportmonks/seasons.json');
+
+const token = process.env.MONK_TOKEN;
+if (!token) {
+  console.error('MONK_TOKEN environment variable is required');
+  process.exit(1);
+}
+
+try {
+  const res = await fetch(
+    `${SPORTMONKS_BASE}/leagues/${PREMIER_LEAGUE_ID}?include=currentSeason`,
+    {
+      headers: { Authorization: token },
+      signal: AbortSignal.timeout(30_000),
+    },
+  );
+
+  if (!res.ok) {
+    console.error(`Sportmonks API error: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+
+  const { data } = await res.json();
+
+  if (!data?.currentSeason?.id) {
+    console.error(
+      `Sportmonks returned no currentSeason for league ${PREMIER_LEAGUE_ID}`,
+    );
+    process.exit(1);
+  }
+
+  const newSeasonId = data.currentSeason.id;
+
+  const existing = JSON.parse(await readFile(seasonsPath, 'utf-8'));
+  const oldSeasonId = existing.premierLeague.seasonId;
+
+  if (oldSeasonId === newSeasonId) {
+    console.log(`Season ID unchanged (${oldSeasonId}). No update needed.`);
+    process.exit(0);
+  }
+
+  existing.premierLeague.seasonId = newSeasonId;
+  await writeFile(seasonsPath, `${JSON.stringify(existing, null, 2)}\n`);
+
+  console.log(`Season ID updated: ${oldSeasonId} → ${newSeasonId}`);
+} catch (error) {
+  console.error('sync-seasons failed:', error.message);
+  process.exit(1);
+}

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -2,7 +2,7 @@ import { type StandingEntity, smStandings } from '@/lib/sportmonks';
 
 export async function getStandings(): Promise<StandingEntity[]> {
   try {
-    const { data, ...rest } = await smStandings(undefined, {
+    const { data, ...rest } = await smStandings({
       include: [
         ['participant', ['name', 'short_code', 'image_path'].join()].join(':'),
         'details.type',

--- a/src/lib/sportmonks/seasons.json
+++ b/src/lib/sportmonks/seasons.json
@@ -1,0 +1,5 @@
+{
+  "premierLeague": {
+    "seasonId": 25583
+  }
+}

--- a/src/lib/sportmonks/standings.ts
+++ b/src/lib/sportmonks/standings.ts
@@ -1,9 +1,5 @@
+import seasons from './seasons.json';
 import { type Sportmonks, sportmonks } from './sportmonks';
-
-// Needed for the static table endpoint - We will need to find a way to look this up based on the
-// team at some point maybe create some sort of highly cached current season endpoint.
-// FOR NOW THIS HAS TO BE UPDATED MANUALLY EVERY SEASON!!!
-const TEMP_SEASON_ID = 25583;
 
 export type StandingEntity = {
   id: number;
@@ -59,12 +55,9 @@ export type StandingsEndpoint = {
   data: StandingEntity[];
 } & Sportmonks;
 
-export async function smStandings(
-  _id: string | undefined,
-  query: object,
-): Promise<StandingsEndpoint> {
+export async function smStandings(query: object): Promise<StandingsEndpoint> {
   return sportmonks
-    .url(`/standings/seasons/${TEMP_SEASON_ID}`)
+    .url(`/standings/seasons/${seasons.premierLeague.seasonId}`)
     .query(query)
     .get() as Promise<StandingsEndpoint>;
 }


### PR DESCRIPTION
## Summary

Closes #34

- Remove hardcoded `TEMP_SEASON_ID` from `src/lib/sportmonks/standings.ts` — season ID now read from `src/lib/sportmonks/seasons.json`
- Add `scripts/sync-seasons.mjs` to fetch the current PL season from Sportmonks `/leagues/8?include=currentSeason`
- Add `.github/workflows/sync-seasons.yml` — monthly cron (+ manual dispatch) that runs the script and opens a PR when the season changes
- Workflow is idempotent (fixed branch + force-push, reuses existing PR) and uses a GitHub App token so the resulting PR triggers CI

### Prerequisites (already configured)

- `MONK_TOKEN` org secret (Actions + Dependabot)
- `APP_ID` / `APP_PK` org secrets for the GitHub App

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn biome ci .` passes
- [x] `yarn knip` passes
- [x] `yarn test` passes (122/122)
- [x] `yarn build` passes
- [x] `grep -r "TEMP_SEASON" src/` returns nothing
- [ ] Standings table renders correctly on preview deployment
- [ ] Trigger `sync-seasons` workflow manually via `workflow_dispatch` after merging to validate end-to-end