### PR TITLE
ci(lefthook): run knip on pre-commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,8 @@ pre-commit:
       glob: "package.json"
       run: npx sort-package-json
       stage_fixed: true
+    knip:
+      run: yarn knip
     test:
       run: yarn test
     typecheck:


### PR DESCRIPTION
## Summary
- Add `knip` as a pre-commit command in `lefthook.yml`, alongside the existing `test` and `typecheck` checks, so dead-code detection runs at commit time (not just on demand).

## Test plan
- [x] `git commit` on this branch ran the pre-commit hook: knip (3.3s), test (4.5s), typecheck (2.2s) all passed.
- [ ] Verify CI stays green.

## Notes
- `yarn knip` emits one configuration hint today (`.claude/**` ignore in `knip.config.ts` is redundant now that `.claude/worktrees/` is gitignored). It exits 0, so the hook does not block — worth a follow-up to drop.