### PR TITLE
perf(hooks): scope pre-commit test to related, move full suites to pre-push

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -25,6 +25,14 @@ Concurrency is configured to cancel in-progress runs on PRs when new commits are
 
 A top-level `permissions: contents: read` block restricts all jobs to read-only token access by default. The `build` job overrides this with `contents: read` + `deployments: write` for Vercel deployment.
 
+## Git Hooks (lefthook)
+
+Config: `lefthook.yml`
+
+- **pre-commit** runs scoped checks on staged files only: `biome`, `sort-package-json`, `knip`, and `vitest related` (JS/TS staged files only). Docs-only commits incur near-zero hook cost.
+- **pre-push** runs project-wide `yarn typecheck` and full `yarn test` once before the push, preserving CI parity without per-commit latency.
+- Never use `--no-verify`. Pre-commit failures must be fixed, not bypassed (root `CLAUDE.md`).
+
 ## Vercel Deployment
 
 The `build` job uses the Vercel CLI (`vercel` devDependency) with three required repository secrets:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,7 +11,13 @@ pre-commit:
       stage_fixed: true
     knip:
       run: yarn knip
-    test:
-      run: yarn test
+    test-related:
+      glob: "*.{js,jsx,ts,tsx}"
+      run: yarn vitest related --run {staged_files}
+
+pre-push:
+  commands:
     typecheck:
       run: yarn typecheck
+    test:
+      run: yarn test


### PR DESCRIPTION
## Summary

- Replaces `yarn test` (full suite, every commit) in `pre-commit` with `yarn vitest related --run {staged_files}`, gated to JS/TS staged files via `glob`
- Moves `yarn typecheck` and full `yarn test` to a new `pre-push` hook — fires once before the network round-trip rather than per commit
- Documents the pre-commit vs pre-push split in `.github/CLAUDE.md`

Covers risk R7 from the post-Phase 4 architectural review.

## Test plan

- [x] Docs-only commit: `test-related` skipped, knip ran — verified in the commit above (3.72s total)
- [x] `lefthook run pre-push --force`: full test suite (11 files, 121 tests) + typecheck both pass
- [ ] On a commit touching a JS/TS file: `vitest related` should run only covering specs

## References

Closes #36