### PR TITLE
refactor(shite): apply transform at the data layer

### DIFF
--- a/src/components/FixtureCard/FixtureCard.tsx
+++ b/src/components/FixtureCard/FixtureCard.tsx
@@ -7,7 +7,6 @@ import {
   type FixtureEntity,
   REGULAR_TIME_ACTIVE_STATES,
 } from '@/lib/sportmonks';
-import { shite } from '@/lib/utils';
 import { Card, type CardProps } from '../Card/Card';
 import { LeagueLogo } from '../LeagueLogo/LeagueLogo';
 import styles from './FixtureCard.module.scss';
@@ -121,7 +120,7 @@ export function FixtureCard({
             />
             <span>{league.name}</span>
           </div>
-          <div>{shite(venue?.name)}</div>
+          <div>{venue?.name}</div>
         </footer>
       </HeadingLevel>
     </Card>

--- a/src/components/FixtureCard/FixtureCardTeam.tsx
+++ b/src/components/FixtureCard/FixtureCardTeam.tsx
@@ -1,5 +1,4 @@
 import type { EntityBase } from '@/lib/sportmonks';
-import { shite } from '@/lib/utils';
 import { TeamLogo } from '../TeamLogo/TeamLogo';
 import styles from './FixtureCard.module.scss';
 
@@ -15,8 +14,6 @@ export function FixtureCardTeam({
   short_code,
   isLoading,
 }: FixtureCardTeamProps) {
-  const properName = shite(name);
-
   const loadingClassname = isLoading ? 'loading' : '';
 
   return (
@@ -29,7 +26,7 @@ export function FixtureCardTeam({
         fallback={image_path}
       />
       <div className={[styles.TeamName, loadingClassname].join(' ')}>
-        {properName}
+        {name}
       </div>
       <div className={[styles.TeamAbbr, loadingClassname].join(' ')}>
         {short_code}

--- a/src/components/GameCard/GameCardBilling.tsx
+++ b/src/components/GameCard/GameCardBilling.tsx
@@ -2,7 +2,6 @@
 
 import { Textfit } from 'react-textfit';
 import type { EntityBase } from '@/lib/sportmonks';
-import { shite } from '@/lib/utils';
 import styles from './GameCard.module.scss';
 
 export function GameCardBilling({
@@ -16,14 +15,14 @@ export function GameCardBilling({
     <div className={styles.MainBilling}>
       <Textfit mode='single' max={500}>
         <h2>
-          {shite(localTeam.name)}
+          {localTeam.name}
           <span>{localTeam.id !== 19 && ' vs'}</span>
         </h2>
       </Textfit>
       <Textfit mode='single' max={500}>
         <h2>
           <span>{visitorTeam.id !== 19 && 'vs '}</span>
-          {shite(visitorTeam.name)}
+          {visitorTeam.name}
         </h2>
       </Textfit>
     </div>

--- a/src/components/LeagueTable/LeagueTable.tsx
+++ b/src/components/LeagueTable/LeagueTable.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import type { StandingEntity } from '@/lib/sportmonks';
-import { shite } from '@/lib/utils';
 import { Card } from '../Card/Card';
 import { TeamLogo } from '../TeamLogo/TeamLogo';
 import styles from './LeagueTable.module.scss';
@@ -36,14 +35,12 @@ export function LeagueTable({ standings }: { standings: StandingEntity[] }) {
           <td>
             <TeamLogo
               teamId={team.participant.id}
-              name={shite(team.participant.name)}
+              name={team.participant.name}
               fallback={team.participant.image_path}
             />
-            <span className={styles.TeamName}>
-              {shite(team.participant.name)}
-            </span>
+            <span className={styles.TeamName}>{team.participant.name}</span>
             <span className={styles.ShortName}>
-              {shite(team.participant.short_code)}
+              {team.participant.short_code}
             </span>
           </td>
           <td>{team.stats['overall-matches-played']}</td>

--- a/src/lib/data/fixtures.ts
+++ b/src/lib/data/fixtures.ts
@@ -1,6 +1,20 @@
 import { type FixtureEntity, smFixtures, smTvStation } from '@/lib/sportmonks';
+import { shite } from '@/lib/utils';
 
 const USA_COUNTRY_ID = 3483;
+
+function applyShite(fixture: FixtureEntity): FixtureEntity {
+  return {
+    ...fixture,
+    participants: fixture.participants?.map((p) => ({
+      ...p,
+      name: shite(p.name),
+    })),
+    venue: fixture.venue
+      ? { ...fixture.venue, name: shite(fixture.venue.name) }
+      : fixture.venue,
+  };
+}
 
 export async function getFixtures(): Promise<FixtureEntity[]> {
   try {
@@ -27,7 +41,7 @@ export async function getFixtures(): Promise<FixtureEntity[]> {
         ...params,
         page: String(page),
       });
-      all.push(...data);
+      all.push(...data.map(applyShite));
       if (!pagination.has_more) break;
       page += 1;
     }
@@ -73,7 +87,7 @@ export async function getNextFixture(): Promise<FixtureEntity[]> {
 
     console.info(rest);
 
-    return data;
+    return data.map(applyShite);
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -1,4 +1,5 @@
 import { type StandingEntity, smStandings } from '@/lib/sportmonks';
+import { shite } from '@/lib/utils';
 
 export async function getStandings(): Promise<StandingEntity[]> {
   try {
@@ -12,8 +13,13 @@ export async function getStandings(): Promise<StandingEntity[]> {
 
     console.info(rest);
 
-    const cleanData = data.map(({ details, ...rest }) => ({
+    const cleanData = data.map(({ details, participant, ...rest }) => ({
       ...rest,
+      participant: {
+        ...participant,
+        name: shite(participant.name),
+        short_code: shite(participant.short_code),
+      },
       stats: Object.fromEntries(
         details.map(({ type, value }) => [type.code, value]),
       ),


### PR DESCRIPTION
## Summary

- Move rival-name rewrites (`shite`) into `src/lib/data/` so the rest of the app is transparent to the mapping
- `getFixtures`/`getNextFixture`: rewrite `participants[].name` and `venue.name` on the way out via a private `applyShite` helper
- `getStandings`: rewrite `participant.name` and `participant.short_code` inside the existing `data.map(…)` reshape
- Drop `shite` imports from `FixtureCard`, `FixtureCardTeam`, `GameCardBilling`, `LeagueTable` — these components now render whatever name they receive

The `shite()` function in `src/lib/utils/shite.ts` is unchanged.

## Side effect (cosmetic, intentional)

`<TeamLogo name={…}>` in `FixtureCardTeam` and `GameCard` previously received the raw team name for alt/fallback text while the visible label was rewritten. It now receives the rewritten name — alt text for Tottenham reads "Totnum Shitspur." Consistent with the deliberate mangling; screen readers now match visible text.

## Verification

- `yarn typecheck` ✅
- `yarn build` ✅
- `grep -rEo "Tottenham|Hotspur|Totnum|Shitspur" .next/static/ || echo "clean"` → `clean` ✅

## References

Closes #37