### PR TITLE
chore(deps): declare node >=24 engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "vite": "7.3.2",
     "vitest": "4.0.18"
   },
-  "packageManager": "yarn@4.13.0"
+  "packageManager": "yarn@4.13.0",
+  "engines": {
+    "node": ">=24.0.0"
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `engines: { node: ">=24.0.0" }` to `package.json` — the only piece missing from issue #40's acceptance criteria
- `.nvmrc` was already `24`; CI and sync-seasons workflows already read `.nvmrc`; `vercel.json` inherits the platform default (Node 24 LTS)

## Test plan

- [ ] CI green: biome / knip / typecheck / test / build / e2e / lighthouse
- [ ] Vercel preview build logs confirm Node 24 runtime
- [ ] No new deprecation warnings in build output vs. main

Closes #40