### PR TITLE
chore: remove stray Sportmonks debug console calls

### DIFF
--- a/src/components/GameCard/GameCard.tsx
+++ b/src/components/GameCard/GameCard.tsx
@@ -20,8 +20,6 @@ export function GameCard({
 
   const isHomeGame = localTeam?.id === 19;
 
-  console.log(isHomeGame);
-
   return (
     <div className={styles._}>
       {Logo && <Logo className={styles.Logo} />}

--- a/src/lib/data/fixtures.ts
+++ b/src/lib/data/fixtures.ts
@@ -55,7 +55,7 @@ export async function getFixtures(): Promise<FixtureEntity[]> {
 
 export async function getNextFixture(): Promise<FixtureEntity[]> {
   try {
-    const { data, ...rest } = await smFixtures(undefined, {
+    const { data } = await smFixtures(undefined, {
       include: [
         'league:name,image_path',
         'participants.sidelined.player',
@@ -84,8 +84,6 @@ export async function getNextFixture(): Promise<FixtureEntity[]> {
         }),
     );
     data[0].tvstations = tvstations;
-
-    console.info(rest);
 
     return data.map(applyShite);
   } catch (error) {

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -3,15 +3,13 @@ import { shite } from '@/lib/utils';
 
 export async function getStandings(): Promise<StandingEntity[]> {
   try {
-    const { data, ...rest } = await smStandings({
+    const { data } = await smStandings({
       include: [
         ['participant', ['name', 'short_code', 'image_path'].join()].join(':'),
         'details.type',
         'form',
       ].join(';'),
     });
-
-    console.info(rest);
 
     const cleanData = data.map(({ details, participant, ...rest }) => ({
       ...rest,


### PR DESCRIPTION
## Summary

- Deletes three leftover `console.info`/`console.log` calls that fired on every RSC render and polluted Vercel production runtime logs with raw Sportmonks pagination/subscription metadata objects
- Cleans up the now-unused `...rest` destructuring in `getNextFixture` (`fixtures.ts`) and `getStandings` (`standings.ts`) — the spread had no purpose beyond feeding the deleted log lines
- Three other calls from the original issue (#17) were already removed in prior refactors

## Files changed

| File | Change |
|---|---|
| `src/lib/data/fixtures.ts` | Remove `console.info(rest)` + simplify destructuring to `{ data }` |
| `src/lib/data/standings.ts` | Remove `console.info(rest)` + simplify destructuring to `{ data }` |
| `src/components/GameCard/GameCard.tsx` | Remove `console.log(isHomeGame)` |

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn biome check` — no unused-variable warnings
- [x] `yarn test` — 121/121 pass
- [x] Pre-push hooks pass (full test suite + typecheck)
- [ ] After deploy: confirm Vercel production runtime logs no longer contain `{ pagination: { count... } }` bodies on HTTP 200 responses

Closes #17