### PR TITLE
feat(metadata): add sitemap.ts and robots.ts routes

### DIFF
--- a/e2e/metadata-routes.spec.ts
+++ b/e2e/metadata-routes.spec.ts
@@ -27,11 +27,10 @@ test('GET /opengraph-image returns 200', async ({ request }) => {
   expect(response.ok()).toBeTruthy();
 });
 
-// Commented out until sitemap.ts route is added — see #43
-// test('GET /sitemap.xml returns 200', async ({ request }) => {
-//   const response = await request.get('/sitemap.xml');
-//   expect(response.ok()).toBeTruthy();
-// });
+test('GET /sitemap.xml returns 200', async ({ request }) => {
+  const response = await request.get('/sitemap.xml');
+  expect(response.ok()).toBeTruthy();
+});
 
 test('GET /robots.txt returns 200', async ({ request }) => {
   const response = await request.get('/robots.txt');

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-# For our generated icons
-Allow: /icon/*
-
-# For our generated OG images
-Allow: /opengraph-image/*

--- a/src/app/robots.spec.ts
+++ b/src/app/robots.spec.ts
@@ -27,6 +27,7 @@ describe('robots', () => {
   it('returns robots for a known branch hostname', async () => {
     mockHost('tacomagooners.com');
     const result = await robots();
+    expect(result.rules).toEqual({ userAgent: '*', allow: '/' });
     expect(result.sitemap).toBe('https://tacomagooners.com/sitemap.xml');
   });
 
@@ -40,7 +41,7 @@ describe('robots', () => {
     process.env.VERCEL_ENV = 'preview';
     mockHost('app-git-foo-arsenalamerica.vercel.app');
     const result = await robots();
-    expect(result.sitemap).toMatch(/^https:\/\/boisegooners\.com/);
+    expect(result.sitemap).toBe('https://boisegooners.com/sitemap.xml');
   });
 
   it('calls notFound() and warns for unknown host in production', async () => {

--- a/src/app/robots.spec.ts
+++ b/src/app/robots.spec.ts
@@ -1,0 +1,57 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import robots from './robots';
+
+vi.mock('next/headers');
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+const mockHost = (host: string | null) =>
+  vi.mocked(headers).mockResolvedValue({
+    get: () => host,
+  } as unknown as Awaited<ReturnType<typeof headers>>);
+
+describe('robots', () => {
+  const originalEnv = process.env.VERCEL_ENV;
+
+  afterEach(() => {
+    process.env.VERCEL_ENV = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('returns robots for a known branch hostname', async () => {
+    mockHost('tacomagooners.com');
+    const result = await robots();
+    expect(result.sitemap).toBe('https://tacomagooners.com/sitemap.xml');
+  });
+
+  it('returns tacomagooners robots on localhost', async () => {
+    mockHost('localhost:3000');
+    const result = await robots();
+    expect(result.sitemap).toBe('https://tacomagooners.com/sitemap.xml');
+  });
+
+  it('falls back to PREVIEW_FALLBACK for unknown host on preview', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    mockHost('app-git-foo-arsenalamerica.vercel.app');
+    const result = await robots();
+    expect(result.sitemap).toMatch(/^https:\/\/boisegooners\.com/);
+  });
+
+  it('calls notFound() and warns for unknown host in production', async () => {
+    process.env.VERCEL_ENV = 'production';
+    mockHost('not-a-branch.example');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(robots()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('not-a-branch.example'),
+    );
+  });
+});

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next';
+
+import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders';
+
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const host = await resolveTenantFromHeaders({
+    caller: 'robots',
+    strict: true,
+  });
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `https://${host}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.spec.ts
+++ b/src/app/sitemap.spec.ts
@@ -38,6 +38,7 @@ describe('sitemap', () => {
   it('returns tacomagooners sitemap on localhost', async () => {
     mockHost('localhost:3000');
     const entries = await sitemap();
+    expect(entries).toHaveLength(3);
     expect(entries[0].url).toBe('https://tacomagooners.com');
   });
 
@@ -45,7 +46,8 @@ describe('sitemap', () => {
     process.env.VERCEL_ENV = 'preview';
     mockHost('app-git-foo-arsenalamerica.vercel.app');
     const entries = await sitemap();
-    expect(entries[0].url).toMatch(/^https:\/\/boisegooners\.com/);
+    expect(entries).toHaveLength(3);
+    expect(entries[0].url).toBe('https://boisegooners.com');
   });
 
   it('calls notFound() and warns for unknown host in production', async () => {

--- a/src/app/sitemap.spec.ts
+++ b/src/app/sitemap.spec.ts
@@ -1,0 +1,62 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import sitemap from './sitemap';
+
+vi.mock('next/headers');
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+const mockHost = (host: string | null) =>
+  vi.mocked(headers).mockResolvedValue({
+    get: () => host,
+  } as unknown as Awaited<ReturnType<typeof headers>>);
+
+describe('sitemap', () => {
+  const originalEnv = process.env.VERCEL_ENV;
+
+  afterEach(() => {
+    process.env.VERCEL_ENV = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('returns sitemap entries for a known branch hostname', async () => {
+    mockHost('tacomagooners.com');
+    const entries = await sitemap();
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.url)).toEqual([
+      'https://tacomagooners.com',
+      'https://tacomagooners.com/fixtures',
+      'https://tacomagooners.com/table',
+    ]);
+  });
+
+  it('returns tacomagooners sitemap on localhost', async () => {
+    mockHost('localhost:3000');
+    const entries = await sitemap();
+    expect(entries[0].url).toBe('https://tacomagooners.com');
+  });
+
+  it('falls back to PREVIEW_FALLBACK for unknown host on preview', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    mockHost('app-git-foo-arsenalamerica.vercel.app');
+    const entries = await sitemap();
+    expect(entries[0].url).toMatch(/^https:\/\/boisegooners\.com/);
+  });
+
+  it('calls notFound() and warns for unknown host in production', async () => {
+    process.env.VERCEL_ENV = 'production';
+    mockHost('not-a-branch.example');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(sitemap()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('not-a-branch.example'),
+    );
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next';
+
+import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders';
+
+const ROUTES = ['', '/fixtures', '/table'] as const;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const host = await resolveTenantFromHeaders({
+    caller: 'sitemap',
+    strict: true,
+  });
+
+  const lastModified = new Date();
+
+  return ROUTES.map((path) => ({
+    url: `https://${host}${path}`,
+    lastModified,
+  }));
+}

--- a/src/lib/tenant/CLAUDE.md
+++ b/src/lib/tenant/CLAUDE.md
@@ -8,7 +8,7 @@ Shared helpers for resolving which branch site (tenant) a request belongs to.
 
 ## Callers
 
-Used by the three metadata routes: `src/app/manifest.ts`, `src/app/opengraph-image.tsx`, `src/app/icon.tsx`. All call with `strict: true`.
+Used by the five metadata routes: `src/app/manifest.ts`, `src/app/opengraph-image.tsx`, `src/app/icon.tsx`, `src/app/sitemap.ts`, `src/app/robots.ts`. All call with `strict: true`.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Adds `src/app/sitemap.ts` — per-tenant dynamic sitemap covering `/`, `/fixtures`, `/table`, using the existing `resolveTenantFromHeaders` pattern
- Adds `src/app/robots.ts` — per-tenant dynamic robots, replacing `public/robots.txt` with a typed `MetadataRoute.Robots` that includes a `Sitemap:` reference pointing at the correct host
- Deletes `public/robots.txt` — static file would shadow the new route handler; also the existing file was malformed (bare `Allow:` directives without a `User-Agent:` block)
- Uncomments the sitemap smoke test in `e2e/metadata-routes.spec.ts`
- Updates `src/lib/tenant/CLAUDE.md` to list the two new callers

Both routes follow the same per-tenant pattern as `manifest.ts`, `icon.tsx`, and `opengraph-image.tsx` — `strict: true` so unknown production hosts hit `notFound()`.

## Test plan

- [ ] `yarn typecheck` passes
- [ ] `yarn test` passes (129 tests, including 8 new for sitemap/robots)
- [ ] `yarn build` passes
- [ ] `yarn e2e` passes (including re-enabled `/sitemap.xml` smoke test)
- [ ] Manual: `curl http://localhost:3000/sitemap.xml?domain=tacomagooners.com` → 200, `<urlset>` with `/`, `/fixtures`, `/table`
- [ ] Manual: `curl http://localhost:3000/robots.txt?domain=tacomagooners.com` → 200, valid robots with `Sitemap:` line

Closes #43