### PR TITLE
fix(tenant): stop metadata routes from triggering not-found.tsx for unknown hosts

### DIFF
--- a/src/app/icon.spec.tsx
+++ b/src/app/icon.spec.tsx
@@ -7,11 +7,6 @@ import Icon from './icon';
 import { ICON_SIZES } from './icon-sizes';
 
 vi.mock('next/headers');
-vi.mock('next/navigation', () => ({
-  notFound: vi.fn(() => {
-    throw new Error('NEXT_NOT_FOUND');
-  }),
-}));
 
 const mockHost = (host: string) =>
   vi.mocked(headers).mockResolvedValue({

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -14,10 +14,7 @@ export function generateImageMetadata() {
 }
 
 export default async function Icon({ id }: { id: Promise<string> | string }) {
-  const domain = await resolveTenantFromHeaders({
-    caller: 'icon',
-    strict: true,
-  });
+  const domain = await resolveTenantFromHeaders({ caller: 'icon' });
 
   const Logo = branchLogo[domain];
   const rasterSrc = branchLogoSrc[domain];

--- a/src/app/manifest.spec.ts
+++ b/src/app/manifest.spec.ts
@@ -1,15 +1,9 @@
 import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Manifest from './manifest';
 
 vi.mock('next/headers');
-vi.mock('next/navigation', () => ({
-  notFound: vi.fn(() => {
-    throw new Error('NEXT_NOT_FOUND');
-  }),
-}));
 
 const mockHost = (host: string | null) =>
   vi.mocked(headers).mockResolvedValue({
@@ -43,13 +37,14 @@ describe('manifest', () => {
     expect(manifest.name).toBe('Boise Gooners');
   });
 
-  it('calls notFound() and warns for unknown host in production', async () => {
+  it('warns and falls back to DOMAINS[0] for unknown host in production', async () => {
     process.env.VERCEL_ENV = 'production';
     mockHost('not-a-branch.example');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await expect(Manifest()).rejects.toThrow('NEXT_NOT_FOUND');
-    expect(notFound).toHaveBeenCalled();
+    const manifest = await Manifest();
+
+    expect(manifest.name).toBe('Boise Gooners');
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('not-a-branch.example'),
     );

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -6,10 +6,7 @@ import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders'
 import { ICON_SIZES } from './icon-sizes';
 
 export default async function Manifest(): Promise<MetadataRoute.Manifest> {
-  const branchSite = await resolveTenantFromHeaders({
-    caller: 'manifest',
-    strict: true,
-  });
+  const branchSite = await resolveTenantFromHeaders({ caller: 'manifest' });
 
   const branch = branchData[branchSite];
 

--- a/src/app/not-found.spec.tsx
+++ b/src/app/not-found.spec.tsx
@@ -13,7 +13,7 @@ vi.mock('next/image', () => ({
 describe('NotFound', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('warns with host and pathname', async () => {
+  it('warns with host and pathname when middleware ran', async () => {
     vi.mocked(headers).mockResolvedValue({
       get: (k: string) =>
         k === 'host'
@@ -29,5 +29,19 @@ describe('NotFound', () => {
 
     expect(warn).toHaveBeenCalledWith('[404] tacomagooners.com/oops');
     expect(baseElement).toBeTruthy();
+  });
+
+  it('warns with middleware-excluded marker when x-pathname is absent', async () => {
+    vi.mocked(headers).mockResolvedValue({
+      get: (k: string) => (k === 'host' ? 'tacomagooners.com' : null),
+    } as unknown as Awaited<ReturnType<typeof headers>>);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const ui = await NotFound();
+    render(ui);
+
+    expect(warn).toHaveBeenCalledWith(
+      '[404] tacomagooners.com(middleware-excluded route)',
+    );
   });
 });

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default async function NotFound() {
   const h = await headers();
   const host = h.get('host') ?? 'unknown';
-  const pathname = h.get('x-pathname') ?? '(unknown path)';
+  const pathname = h.get('x-pathname') ?? '(middleware-excluded route)';
   console.warn(`[404] ${host}${pathname}`);
   return <Image src={notFound} alt='Not Found' />;
 }

--- a/src/app/opengraph-image.spec.tsx
+++ b/src/app/opengraph-image.spec.tsx
@@ -6,11 +6,6 @@ import { branchData } from '@/data';
 import Image from './opengraph-image';
 
 vi.mock('next/headers');
-vi.mock('next/navigation', () => ({
-  notFound: vi.fn(() => {
-    throw new Error('NEXT_NOT_FOUND');
-  }),
-}));
 
 const mockHost = (host: string) =>
   vi.mocked(headers).mockResolvedValue({

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -10,10 +10,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const domain = await resolveTenantFromHeaders({
-    caller: 'opengraph-image',
-    strict: true,
-  });
+  const domain = await resolveTenantFromHeaders({ caller: 'opengraph-image' });
 
   const Logo = branchLogo[domain];
   const rasterSrc = branchLogoSrc[domain];

--- a/src/app/robots.spec.ts
+++ b/src/app/robots.spec.ts
@@ -1,15 +1,9 @@
 import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import robots from './robots';
 
 vi.mock('next/headers');
-vi.mock('next/navigation', () => ({
-  notFound: vi.fn(() => {
-    throw new Error('NEXT_NOT_FOUND');
-  }),
-}));
 
 const mockHost = (host: string | null) =>
   vi.mocked(headers).mockResolvedValue({
@@ -44,13 +38,14 @@ describe('robots', () => {
     expect(result.sitemap).toBe('https://boisegooners.com/sitemap.xml');
   });
 
-  it('calls notFound() and warns for unknown host in production', async () => {
+  it('warns and falls back to PREVIEW_FALLBACK for unknown host in production', async () => {
     process.env.VERCEL_ENV = 'production';
     mockHost('not-a-branch.example');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await expect(robots()).rejects.toThrow('NEXT_NOT_FOUND');
-    expect(notFound).toHaveBeenCalled();
+    const result = await robots();
+
+    expect(result.sitemap).toBe('https://boisegooners.com/sitemap.xml');
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('not-a-branch.example'),
     );

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,10 +3,7 @@ import type { MetadataRoute } from 'next';
 import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders';
 
 export default async function robots(): Promise<MetadataRoute.Robots> {
-  const host = await resolveTenantFromHeaders({
-    caller: 'robots',
-    strict: true,
-  });
+  const host = await resolveTenantFromHeaders({ caller: 'robots' });
 
   return {
     rules: {

--- a/src/app/sitemap.spec.ts
+++ b/src/app/sitemap.spec.ts
@@ -1,15 +1,9 @@
 import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import sitemap from './sitemap';
 
 vi.mock('next/headers');
-vi.mock('next/navigation', () => ({
-  notFound: vi.fn(() => {
-    throw new Error('NEXT_NOT_FOUND');
-  }),
-}));
 
 const mockHost = (host: string | null) =>
   vi.mocked(headers).mockResolvedValue({
@@ -50,13 +44,14 @@ describe('sitemap', () => {
     expect(entries[0].url).toBe('https://boisegooners.com');
   });
 
-  it('calls notFound() and warns for unknown host in production', async () => {
+  it('warns and falls back to PREVIEW_FALLBACK for unknown host in production', async () => {
     process.env.VERCEL_ENV = 'production';
     mockHost('not-a-branch.example');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await expect(sitemap()).rejects.toThrow('NEXT_NOT_FOUND');
-    expect(notFound).toHaveBeenCalled();
+    const entries = await sitemap();
+
+    expect(entries[0].url).toBe('https://boisegooners.com');
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('not-a-branch.example'),
     );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,10 +5,7 @@ import { resolveTenantFromHeaders } from '@/lib/tenant/resolveTenantFromHeaders'
 const ROUTES = ['', '/fixtures', '/table'] as const;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const host = await resolveTenantFromHeaders({
-    caller: 'sitemap',
-    strict: true,
-  });
+  const host = await resolveTenantFromHeaders({ caller: 'sitemap' });
 
   const lastModified = new Date();
 

--- a/src/lib/tenant/CLAUDE.md
+++ b/src/lib/tenant/CLAUDE.md
@@ -4,12 +4,12 @@ Shared helpers for resolving which branch site (tenant) a request belongs to.
 
 ## Key file
 
-- `resolveTenantFromHeaders.ts` — reads the `Host` header and maps it to a known branch domain. Supports `strict` mode (warns + 404 for unknown production hosts) vs non-strict (falls back to `PREVIEW_FALLBACK`).
+- `resolveTenantFromHeaders.ts` — reads the `Host` header and maps it to a known branch domain. For unknown hosts in production, emits a `[<caller>] unknown host in production: <host>` warning and falls back to `PREVIEW_FALLBACK`. Outside production, falls back silently to `PREVIEW_FALLBACK`. Never calls `notFound()`.
 
 ## Callers
 
-Used by the five metadata routes: `src/app/manifest.ts`, `src/app/opengraph-image.tsx`, `src/app/icon.tsx`, `src/app/sitemap.ts`, `src/app/robots.ts`. All call with `strict: true`.
+Used by the five metadata routes: `src/app/manifest.ts`, `src/app/opengraph-image.tsx`, `src/app/icon.tsx`, `src/app/sitemap.ts`, `src/app/robots.ts`. Each passes its own `caller` identifier for log attribution.
 
 ## Testing
 
-Tests in `resolveTenantFromHeaders.spec.ts` mock `next/headers` and `next/navigation`. The global `vitest.setup.ts` throws on unexpected `console.warn`, so the strict-production test must explicitly mock `console.warn`.
+Tests in `resolveTenantFromHeaders.spec.ts` mock `next/headers`. The global `vitest.setup.ts` installs a `beforeEach` spy on `console.warn` that throws on unexpected calls, so the production-unknown-host test must explicitly mock `console.warn` to override it.

--- a/src/lib/tenant/resolveTenantFromHeaders.spec.ts
+++ b/src/lib/tenant/resolveTenantFromHeaders.spec.ts
@@ -1,15 +1,9 @@
 import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveTenantFromHeaders } from './resolveTenantFromHeaders';
 
 vi.mock('next/headers');
-vi.mock('next/navigation', () => ({
-  notFound: vi.fn(() => {
-    throw new Error('NEXT_NOT_FOUND');
-  }),
-}));
 
 const mockHost = (host: string | null) =>
   vi.mocked(headers).mockResolvedValue({
@@ -26,63 +20,39 @@ describe('resolveTenantFromHeaders', () => {
 
   it('treats a null host header as localhost', async () => {
     mockHost(null);
-    const domain = await resolveTenantFromHeaders({
-      caller: 'test',
-      strict: true,
-    });
+    const domain = await resolveTenantFromHeaders({ caller: 'test' });
     expect(domain).toBe('tacomagooners.com');
   });
 
   it('resolves localhost to tacomagooners.com', async () => {
     mockHost('localhost:3000');
-    const domain = await resolveTenantFromHeaders({
-      caller: 'test',
-      strict: true,
-    });
+    const domain = await resolveTenantFromHeaders({ caller: 'test' });
     expect(domain).toBe('tacomagooners.com');
   });
 
   it('resolves a known host to itself', async () => {
     mockHost('pdxgooners.com');
-    const domain = await resolveTenantFromHeaders({
-      caller: 'test',
-      strict: true,
-    });
+    const domain = await resolveTenantFromHeaders({ caller: 'test' });
     expect(domain).toBe('pdxgooners.com');
   });
 
   it('falls back to PREVIEW_FALLBACK for unknown host on preview', async () => {
     process.env.VERCEL_ENV = 'preview';
     mockHost('app-git-foo-arsenalamerica.vercel.app');
-    const domain = await resolveTenantFromHeaders({
-      caller: 'test',
-      strict: true,
-    });
+    const domain = await resolveTenantFromHeaders({ caller: 'test' });
     expect(domain).toBe('boisegooners.com');
   });
 
-  it('calls notFound() and warns for unknown host in production (strict)', async () => {
+  it('warns and falls back to PREVIEW_FALLBACK for unknown host in production', async () => {
     process.env.VERCEL_ENV = 'production';
     mockHost('bad.example');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    await expect(
-      resolveTenantFromHeaders({ caller: 'test-caller', strict: true }),
-    ).rejects.toThrow('NEXT_NOT_FOUND');
+    const domain = await resolveTenantFromHeaders({ caller: 'test-caller' });
 
-    expect(notFound).toHaveBeenCalled();
+    expect(domain).toBe('boisegooners.com');
     expect(warn).toHaveBeenCalledWith(
       '[test-caller] unknown host in production: bad.example',
     );
-  });
-
-  it('falls back to PREVIEW_FALLBACK for unknown host in production (non-strict)', async () => {
-    process.env.VERCEL_ENV = 'production';
-    mockHost('bad.example');
-    const domain = await resolveTenantFromHeaders({
-      caller: 'test',
-      strict: false,
-    });
-    expect(domain).toBe('boisegooners.com');
   });
 });

--- a/src/lib/tenant/resolveTenantFromHeaders.ts
+++ b/src/lib/tenant/resolveTenantFromHeaders.ts
@@ -1,5 +1,4 @@
 import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
 
 import { branchData } from '@/data';
 
@@ -9,19 +8,12 @@ export const PREVIEW_FALLBACK = Object.keys(branchData)[0];
 const LOCAL_FALLBACK = 'tacomagooners.com';
 
 interface ResolveTenantOptions {
-  /** Identifier for log messages, e.g. 'manifest', 'icon'. */
+  /** Identifier for log messages, e.g. 'manifest', 'opengraph-image', 'icon'. */
   caller: string;
-  /**
-   * When true and the host is unknown in production,
-   * logs a warning and calls notFound().
-   * When false, falls back to PREVIEW_FALLBACK regardless of environment.
-   */
-  strict: boolean;
 }
 
 export async function resolveTenantFromHeaders({
   caller,
-  strict,
 }: ResolveTenantOptions): Promise<string> {
   const headersList = await headers();
   const host = headersList.get('host') || 'localhost';
@@ -29,9 +21,8 @@ export async function resolveTenantFromHeaders({
   if (host.startsWith('localhost')) return LOCAL_FALLBACK;
   if (host in branchData) return host;
 
-  if (strict && process.env.VERCEL_ENV === 'production') {
+  if (process.env.VERCEL_ENV === 'production') {
     console.warn(`[${caller}] unknown host in production: ${host}`);
-    return notFound();
   }
 
   return PREVIEW_FALLBACK;


### PR DESCRIPTION
## Summary

- Removes `notFound()` from `resolveTenantFromHeaders` — unknown production hosts now emit a `[<caller>] unknown host in production: <host>` warning and fall back to `PREVIEW_FALLBACK` instead of rendering `not-found.tsx`
- Removes the `strict` parameter (all five callers passed `strict: true`; the only distinction was the `notFound()` call, which is now gone)
- Updates `not-found.tsx` fallback pathname from `(unknown path)` to `(middleware-excluded route)` so the warning self-identifies when `x-pathname` is absent (i.e., the request bypassed middleware)

## Test plan

- [ ] `yarn typecheck` — clean
- [ ] `yarn test` — 129/129 passing
- [ ] Deploy to preview and confirm `[manifest]`/`[icon]`/`[og]` warnings appear for unknown hosts in Vercel runtime logs; no `[404]` emitted by `not-found.tsx` for metadata route requests
- [ ] Post-deploy: query production runtime logs with `level=warning&query=[404]` over 4h window — expect near-zero entries for known tenant hosts

Closes #18