### PR TITLE
refactor(cache): migrate to Next 16 cache components, remove wretch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      MONK_TOKEN: ${{ secrets.MONK_TOKEN }}
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: ./.github/actions/setup

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ next-env.d.ts
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+.env*.local

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-ios-pwa-prompt": "2.0.6",
-    "react-textfit": "1.1.1",
-    "wretch": "2.11.0"
+    "react-textfit": "1.1.1"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.11.1",

--- a/src/app/[domain]/fixtures/page.tsx
+++ b/src/app/[domain]/fixtures/page.tsx
@@ -1,9 +1,6 @@
 import { FixtureCard } from '@/components';
 import { getFixtures, getNextFixture } from '@/lib/data/fixtures';
 
-// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 60; // 1 minute
-
 export default async function FixturesPage() {
   const upcomingFixtures = await getFixtures();
   const [{ id: nextFixtureId }] = await getNextFixture();

--- a/src/app/[domain]/game-card/page.tsx
+++ b/src/app/[domain]/game-card/page.tsx
@@ -11,9 +11,6 @@ export const metadata: Metadata = {
   },
 };
 
-// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 45; // 45 seconds
-
 export default async function GameCardPage(props: {
   params: Promise<{ domain: string }>;
 }) {

--- a/src/app/[domain]/page.tsx
+++ b/src/app/[domain]/page.tsx
@@ -4,9 +4,6 @@ import { FixtureCard, Main, NextGame } from '@/components';
 import { branchData, branchLogo } from '@/data';
 import { getNextFixture } from '@/lib/data/fixtures';
 
-// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 45; // 45 seconds
-
 export default async function Home(props: {
   params: Promise<{ domain: string }>;
 }) {

--- a/src/app/[domain]/table/page.tsx
+++ b/src/app/[domain]/table/page.tsx
@@ -1,9 +1,6 @@
 import { LeagueTable } from '@/components';
 import { getStandings } from '@/lib/data/standings';
 
-// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 60; // 1 minute
-
 export default async function LeagueTablePage() {
   const standings = await getStandings();
   return <LeagueTable standings={standings} />;

--- a/src/lib/data/fixtures.ts
+++ b/src/lib/data/fixtures.ts
@@ -23,79 +23,79 @@ function applyShite(fixture: FixtureEntity): FixtureEntity {
 export async function getFixtures(): Promise<FixtureEntity[]> {
   cacheLife('minutes');
   cacheTag('fixtures');
-  try {
-    const params = {
-      include: [
-        'league:name,image_path',
-        'participants:name,short_code,image_path',
-        'scores',
-        'state',
-        'periods',
-        'venue:name,city_name',
-      ].join(';'),
-      sort_by: 'starting_at',
-      order: 'asc',
-      per_page: '50',
-    };
 
-    const all: FixtureEntity[] = [];
-    let page = 1;
-    const MAX_PAGES = 2;
+  const params = {
+    include: [
+      'league:name,image_path',
+      'participants:name,short_code,image_path',
+      'scores',
+      'state',
+      'periods',
+      'venue:name,city_name',
+    ].join(';'),
+    sort_by: 'starting_at',
+    order: 'asc',
+    per_page: '50',
+  };
 
-    while (page <= MAX_PAGES) {
-      const { data, pagination } = await smFixtures(undefined, {
-        ...params,
-        page: String(page),
-      });
-      all.push(...data.map(applyShite));
-      if (!pagination.has_more) break;
-      page += 1;
-    }
+  const all: FixtureEntity[] = [];
+  let page = 1;
+  const MAX_PAGES = 2;
 
-    return all;
-  } catch (error) {
-    console.error(error);
-    throw error;
+  while (page <= MAX_PAGES) {
+    const { data, pagination } = await smFixtures(undefined, {
+      ...params,
+      page: String(page),
+    });
+    all.push(...data.map(applyShite));
+    if (!pagination.has_more) break;
+    page += 1;
   }
+
+  return all;
 }
 
 export async function getNextFixture(): Promise<FixtureEntity[]> {
   cacheLife('minutes');
   cacheTag('next-fixture');
-  try {
-    const { data } = await smFixtures(undefined, {
-      include: [
-        'league:name,image_path',
-        'participants.sidelined.player',
-        'scores',
-        'state',
-        'lineups.player',
-        'periods',
-        'tvStations',
-        // 'metadata.type',
-        // 'referees',
-        'venue:name,city_name',
-      ].join(';'),
-      // All active or upcoming fixture states: https://docs.sportmonks.com/football/tutorials-and-guides/tutorials/includes/states#state-interactions
-      filters: 'fixtureStates:1,2,3,22,4,6,21,7,25,9',
-      sort_by: 'starting_at',
-      order: 'asc',
-      per_page: '1',
-    });
 
-    const tvstations = await Promise.all(
-      data[0].tvstations
-        .filter(({ country_id }) => country_id === USA_COUNTRY_ID)
-        .map(async (tvstation) => {
-          const { data } = await smTvStation(tvstation.tvstation_id);
-          return { ...tvstation, ...data };
-        }),
+  const { data } = await smFixtures(undefined, {
+    include: [
+      'league:name,image_path',
+      'participants.sidelined.player',
+      'scores',
+      'state',
+      'lineups.player',
+      'periods',
+      'tvStations',
+      // 'metadata.type',
+      // 'referees',
+      'venue:name,city_name',
+    ].join(';'),
+    // All active or upcoming fixture states: https://docs.sportmonks.com/football/tutorials-and-guides/tutorials/includes/states#state-interactions
+    filters: 'fixtureStates:1,2,3,22,4,6,21,7,25,9',
+    sort_by: 'starting_at',
+    order: 'asc',
+    per_page: '1',
+  });
+
+  if (data.length === 0) {
+    throw new Error(
+      'getNextFixture: no fixture matched active/upcoming state filter',
     );
-    data[0].tvstations = tvstations;
-
-    return data.map(applyShite);
-  } catch (error) {
-    console.error(error);
-    throw error;
   }
+
+  const settled = await Promise.allSettled(
+    data[0].tvstations
+      .filter(({ country_id }) => country_id === USA_COUNTRY_ID)
+      .map(async (tvstation) => {
+        const { data: stationData } = await smTvStation(tvstation.tvstation_id);
+        return { ...tvstation, ...stationData };
+      }),
+  );
+  data[0].tvstations = settled.flatMap((r) =>
+    r.status === 'fulfilled' ? [r.value] : [],
+  );
+
+  return data.map(applyShite);
 }

--- a/src/lib/data/fixtures.ts
+++ b/src/lib/data/fixtures.ts
@@ -1,3 +1,7 @@
+'use cache';
+
+import { cacheLife, cacheTag } from 'next/cache';
+
 import { type FixtureEntity, smFixtures, smTvStation } from '@/lib/sportmonks';
 import { shite } from '@/lib/utils';
 
@@ -17,6 +21,8 @@ function applyShite(fixture: FixtureEntity): FixtureEntity {
 }
 
 export async function getFixtures(): Promise<FixtureEntity[]> {
+  cacheLife('minutes');
+  cacheTag('fixtures');
   try {
     const params = {
       include: [
@@ -54,6 +60,8 @@ export async function getFixtures(): Promise<FixtureEntity[]> {
 }
 
 export async function getNextFixture(): Promise<FixtureEntity[]> {
+  cacheLife('minutes');
+  cacheTag('next-fixture');
   try {
     const { data } = await smFixtures(undefined, {
       include: [

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -1,7 +1,13 @@
+'use cache';
+
+import { cacheLife, cacheTag } from 'next/cache';
+
 import { type StandingEntity, smStandings } from '@/lib/sportmonks';
 import { shite } from '@/lib/utils';
 
 export async function getStandings(): Promise<StandingEntity[]> {
+  cacheLife('hours');
+  cacheTag('standings');
   try {
     const { data } = await smStandings({
       include: [

--- a/src/lib/data/standings.ts
+++ b/src/lib/data/standings.ts
@@ -8,30 +8,26 @@ import { shite } from '@/lib/utils';
 export async function getStandings(): Promise<StandingEntity[]> {
   cacheLife('hours');
   cacheTag('standings');
-  try {
-    const { data } = await smStandings({
-      include: [
-        ['participant', ['name', 'short_code', 'image_path'].join()].join(':'),
-        'details.type',
-        'form',
-      ].join(';'),
-    });
 
-    const cleanData = data.map(({ details, participant, ...rest }) => ({
-      ...rest,
-      participant: {
-        ...participant,
-        name: shite(participant.name),
-        short_code: shite(participant.short_code),
-      },
-      stats: Object.fromEntries(
-        details.map(({ type, value }) => [type.code, value]),
-      ),
-    }));
+  const { data } = await smStandings({
+    include: [
+      ['participant', ['name', 'short_code', 'image_path'].join()].join(':'),
+      'details.type',
+      'form',
+    ].join(';'),
+  });
 
-    return cleanData as unknown as StandingEntity[];
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  const cleanData = data.map(({ details, participant, ...rest }) => ({
+    ...rest,
+    participant: {
+      ...participant,
+      name: shite(participant.name),
+      short_code: shite(participant.short_code),
+    },
+    stats: Object.fromEntries(
+      details.map(({ type, value }) => [type.code, value]),
+    ),
+  }));
+
+  return cleanData as unknown as StandingEntity[];
 }

--- a/src/lib/sportmonks/fixtures.ts
+++ b/src/lib/sportmonks/fixtures.ts
@@ -4,7 +4,7 @@ import {
   ARSENAL_TEAM_ID,
   type EntityBase,
   type Sportmonks,
-  sportmonks,
+  sportmonksFetch,
 } from './sportmonks';
 
 type Participant = {
@@ -64,10 +64,10 @@ export type FixturesEndpoint = {
 
 export async function smFixtures(
   _id: string | undefined,
-  query: object,
+  query: Record<string, string>,
 ): Promise<FixturesEndpoint> {
-  return sportmonks
-    .url(`/fixtures/between/${season.start}/${season.end}/${ARSENAL_TEAM_ID}`)
-    .query(query)
-    .get() as Promise<FixturesEndpoint>;
+  return sportmonksFetch<FixturesEndpoint>(
+    `/fixtures/between/${season.start}/${season.end}/${ARSENAL_TEAM_ID}`,
+    query,
+  );
 }

--- a/src/lib/sportmonks/sportmonks.ts
+++ b/src/lib/sportmonks/sportmonks.ts
@@ -1,6 +1,3 @@
-import wretch from 'wretch';
-import QueryStringAddon from 'wretch/addons/queryString';
-
 export type Sportmonks = {
   subscription: [];
   rate_limit: {
@@ -26,11 +23,24 @@ export type EntityBase = {
 
 export const ARSENAL_TEAM_ID = 19;
 
-export const sportmonks = wretch('https://api.sportmonks.com/v3/football', {
-  cache: 'no-cache',
-  // next: { revalidate: 5 },
-})
-  .headers({ Authorization: `${process.env.MONK_TOKEN}` })
-  .addon(QueryStringAddon)
-  .errorType('json')
-  .resolve((r) => r.json());
+const SPORTMONKS_BASE = 'https://api.sportmonks.com/v3/football';
+
+export async function sportmonksFetch<T>(
+  path: string,
+  params: Record<string, string> = {},
+): Promise<T> {
+  const token = process.env.MONK_TOKEN;
+  if (!token) throw new Error('MONK_TOKEN is not set');
+
+  const url = new URL(`${SPORTMONKS_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+
+  const res = await fetch(url, {
+    headers: { Authorization: token },
+  });
+
+  if (!res.ok) throw new Error(`Sportmonks ${res.status}: ${path}`);
+  return res.json() as Promise<T>;
+}

--- a/src/lib/sportmonks/sportmonks.ts
+++ b/src/lib/sportmonks/sportmonks.ts
@@ -41,6 +41,17 @@ export async function sportmonksFetch<T>(
     headers: { Authorization: token },
   });
 
-  if (!res.ok) throw new Error(`Sportmonks ${res.status}: ${path}`);
+  if (!res.ok) {
+    let detail = '';
+    try {
+      const body = (await res.json()) as { message?: string };
+      detail = body.message ?? '';
+    } catch {
+      // body was not JSON
+    }
+    throw new Error(
+      `Sportmonks ${res.status}${detail ? ` ${detail}` : ''}: ${path}`,
+    );
+  }
   return res.json() as Promise<T>;
 }

--- a/src/lib/sportmonks/standings.ts
+++ b/src/lib/sportmonks/standings.ts
@@ -1,5 +1,5 @@
 import seasons from './seasons.json';
-import { type Sportmonks, sportmonks } from './sportmonks';
+import { type Sportmonks, sportmonksFetch } from './sportmonks';
 
 export type StandingEntity = {
   id: number;
@@ -55,9 +55,11 @@ export type StandingsEndpoint = {
   data: StandingEntity[];
 } & Sportmonks;
 
-export async function smStandings(query: object): Promise<StandingsEndpoint> {
-  return sportmonks
-    .url(`/standings/seasons/${seasons.premierLeague.seasonId}`)
-    .query(query)
-    .get() as Promise<StandingsEndpoint>;
+export async function smStandings(
+  query: Record<string, string>,
+): Promise<StandingsEndpoint> {
+  return sportmonksFetch<StandingsEndpoint>(
+    `/standings/seasons/${seasons.premierLeague.seasonId}`,
+    query,
+  );
 }

--- a/src/lib/sportmonks/tv-station.ts
+++ b/src/lib/sportmonks/tv-station.ts
@@ -1,4 +1,4 @@
-import { type Sportmonks, sportmonks } from './sportmonks';
+import { type Sportmonks, sportmonksFetch } from './sportmonks';
 
 export type TvStationEntity = {
   id: number;
@@ -15,10 +15,10 @@ type TvStationEndpoint = {
 
 export async function smTvStation(
   station_id: number,
-  query?: object,
+  params?: Record<string, string>,
 ): Promise<TvStationEndpoint> {
-  return sportmonks
-    .url(`/tv-stations/${station_id}`)
-    .query(query || {})
-    .get() as Promise<TvStationEndpoint>;
+  return sportmonksFetch<TvStationEndpoint>(
+    `/tv-stations/${station_id}`,
+    params,
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3080,7 +3080,6 @@ __metadata:
     vercel: "npm:51.5.1"
     vite: "npm:7.3.2"
     vitest: "npm:4.0.18"
-    wretch: "npm:2.11.0"
   languageName: unknown
   linkType: soft
 
@@ -7028,13 +7027,6 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
-  languageName: node
-  linkType: hard
-
-"wretch@npm:2.11.0":
-  version: 2.11.0
-  resolution: "wretch@npm:2.11.0"
-  checksum: 10c0/5fea89eea46a29d32b9277d79c96426832f326f9f4ef9d0c5babc8c8747e2b20f7bcb6355c5a7dca2f1f5cab5aad37d94f08d86377015d734acddac93b0fbda1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Replaces the `wretch` client with a native `fetch` wrapper (`sportmonksFetch`) — removes `cache: 'no-cache'` that was bypassing Next.js fetch deduplication
- Adds `'use cache'` + `cacheLife` + `cacheTag` to the data layer (`getFixtures`, `getNextFixture`, `getStandings`) — caching now lives at the data layer, not the page layer
- Removes `export const revalidate` from all four `[domain]` pages — previously the only caching lever; now redundant
- Enables `cacheComponents: true` in `next.config.ts`

### Cache configuration

| Fetcher | `cacheLife` | `cacheTag` |
|---|---|---|
| `getFixtures` | `minutes` | `fixtures` |
| `getNextFixture` | `minutes` | `next-fixture` |
| `getStandings` | `hours` | `standings` |

### Deduplication win

`getNextFixture()` is called from three pages. Previously each call made its own Sportmonks HTTP request. With `'use cache'`, subsequent calls within the same `minutes` window are served from cache with no HTTP request.

## Test plan

- [ ] `yarn typecheck` passes
- [ ] `yarn check` passes (no Biome warnings)
- [ ] `yarn test` passes (131 tests)
- [ ] `yarn build` passes — all four `[domain]` pages render as `◐` (PPR)
- [ ] Preview deployment serves fixtures/standings/game-card correctly
- [ ] Verify Sportmonks call count in runtime logs drops after initial warm-up

## Follow-ups

- #68 — move `tv-station` lookups to a build-time cron sync (alongside `sync-seasons.mjs`)
- On-demand revalidation endpoint (`/api/revalidate` + `revalidateTag`) — deferred; no webhook/cron consumer lined up yet

## References

Closes #44