### PR TITLE
fix(Card): replace ariakit Role with native element via as prop

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,23 +1,19 @@
-import { Role, type RoleProps } from '@ariakit/react';
 import clsx from 'clsx';
-import { forwardRef } from 'react';
+import type { HTMLAttributes } from 'react';
+import { createElement, forwardRef } from 'react';
 import styles from './Card.module.scss';
 
-export type CardProps = RoleProps;
+export type CardProps = HTMLAttributes<HTMLElement> & {
+  as?: 'section' | 'div' | 'article' | 'aside';
+};
 
-export const Card = forwardRef<HTMLDivElement, CardProps>(
-  ({ render = <section />, className, children, ...rest }, ref) => {
-    return (
-      <Role
-        {...rest}
-        ref={ref}
-        render={render}
-        className={clsx(styles._, className)}
-      >
-        {children}
-      </Role>
-    );
-  },
+export const Card = forwardRef<HTMLElement, CardProps>(
+  ({ as = 'section', className, children, ...rest }, ref) =>
+    createElement(
+      as,
+      { ...rest, ref, className: clsx(styles._, className) },
+      children,
+    ),
 );
 
 Card.displayName = 'Card';

--- a/src/components/FixtureCard/FixtureCard.tsx
+++ b/src/components/FixtureCard/FixtureCard.tsx
@@ -13,7 +13,6 @@ import { FixtureCardTeam } from './FixtureCardTeam';
 type FixtureCardProps = Omit<CardProps, 'id'> & Omit<FixtureEntity, 'id'>;
 
 export function FixtureCard({
-  render = <section />,
   name,
   className,
   participants,

--- a/src/components/FixtureCard/FixtureCard.tsx
+++ b/src/components/FixtureCard/FixtureCard.tsx
@@ -22,6 +22,13 @@ export function FixtureCard({
   periods,
   venue,
   state,
+  // Discard remaining entity fields so they don't leak to the DOM via ...rest
+  starting_at: _starting_at,
+  state_id: _state_id,
+  tvstations: _tvstations,
+  has_odds: _has_odds,
+  has_premium_odds: _has_premium_odds,
+  placeholder: _placeholder,
   ...rest
 }: FixtureCardProps) {
   if (!participants) {

--- a/src/components/NextGame/NextGame.tsx
+++ b/src/components/NextGame/NextGame.tsx
@@ -44,7 +44,7 @@ export function NextGame({
   return (
     <>
       <Heading>Match Watch Party</Heading>
-      <Card render={<div />} className={styles._}>
+      <Card as='div' className={styles._}>
         <p>
           <LocalDateTime
             epoch={starting_at_timestamp}

--- a/src/lib/sportmonks/fixtures.ts
+++ b/src/lib/sportmonks/fixtures.ts
@@ -56,6 +56,9 @@ export type FixtureEntity = {
   }[];
   tvstations: { tvstation_id: number; country_id: number }[];
   venue: EntityBase;
+  has_odds?: boolean;
+  has_premium_odds?: boolean;
+  placeholder?: boolean;
 };
 
 export type FixturesEndpoint = {


### PR DESCRIPTION
## Summary

- Removes `@ariakit/react` `Role` from `Card.tsx` to fix a production outage where `TypeError: render is not a function` was thrown on every page render
- Root cause: React 19 version mismatch between standalone `react@19.2.5` and Next.js 16's compiled `react@19.3.0-canary` causes ariakit's `React.isValidElement(<div />)` to return `false`, making it fall through to `render(rest)` and throw
- Replaces `RoleProps`/`render` prop API with an `as` prop (`'section' | 'div' | 'article' | 'aside'`, defaults to `'section'`)
- Updates `FixtureCard` to drop the now-removed `render` destructuring
- Updates `NextGame` to use `as="div"` instead of `render={<div />}`

## Test plan

- [ ] Verify home page no longer shows "Something went wrong" error boundary
- [ ] Verify fixture cards render correctly on `/fixtures`
- [ ] Verify league table renders on `/table`
- [ ] e2e passes on the Vercel preview URL