### PR TITLE
fix(sentry): capture exceptions in all error boundaries

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -18,8 +18,9 @@ Runs on push and pull request to `main`. Jobs:
 
 - **biome**, **knip**, **typecheck**, and **test** run in parallel on all events. **knip** detects unused files, exports, and dependencies; uses `--reporter github-actions` for inline PR annotations.
 - **build** runs after all four pass on all events — runs `vercel build`, then deploys to preview (on `pull_request`) or production (on push to `main`). Exposes `url` as a job output for downstream jobs.
-- **e2e** runs on `pull_request` only, after `build`. Runs Playwright tests against the Vercel preview URL via `PLAYWRIGHT_BASE_URL` (from the `build` job output) and `VERCEL_BYPASS_SECRET`. Installs Chromium only. Uploads `playwright-report/` as a CI artifact on every run.
-- **lighthouse** runs on `pull_request` only, after `build`. Matrix job auditing `/`, `/fixtures`, and `/table` against the Vercel preview URL using `treosh/lighthouse-ci-action`. Runs 3 audits per route and uploads artifacts (`lighthouse-root`, `lighthouse-fixtures`, `lighthouse-table`). Thresholds defined in `lighthouserc.json`. All three matrix checks are required in the `shared-ci` ruleset (`settings.yml`).
+- **e2e** and **lighthouse** both run on `pull_request` only, after `build`, and run in parallel with each other.
+  - **e2e**: Runs Playwright tests against the Vercel preview URL via `PLAYWRIGHT_BASE_URL` (from the `build` job output) and `VERCEL_BYPASS_SECRET`. Installs Chromium only. Uploads `playwright-report/` as a CI artifact on every run.
+  - **lighthouse**: Matrix job auditing `/`, `/fixtures`, and `/table` against the Vercel preview URL using `treosh/lighthouse-ci-action`. Runs 3 audits per route and uploads artifacts (`lighthouse-root`, `lighthouse-fixtures`, `lighthouse-table`). Thresholds defined in `lighthouserc.json`. All three matrix checks are required in the `shared-ci` ruleset (`settings.yml`).
 
 Concurrency is configured to cancel in-progress runs on PRs when new commits are pushed. Runs on `main` are never cancelled.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [build, lighthouse]
+    needs: [build]
     if: github.event_name == 'pull_request'
     env:
       PLAYWRIGHT_BASE_URL: ${{ needs.build.outputs.url }}

--- a/src/components/FixtureCard/FixtureCardBoundary.tsx
+++ b/src/components/FixtureCard/FixtureCardBoundary.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import type { ReactNode } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { FixtureCardError } from './FixtureCardError';
@@ -8,7 +9,10 @@ import { FixtureCardError } from './FixtureCardError';
 // the RSC serialization boundary.
 export function FixtureCardBoundary({ children }: { children: ReactNode }) {
   return (
-    <ErrorBoundary FallbackComponent={FixtureCardError} onError={console.error}>
+    <ErrorBoundary
+      FallbackComponent={FixtureCardError}
+      onError={(error) => Sentry.captureException(error)}
+    >
       {children}
     </ErrorBoundary>
   );

--- a/src/components/RouteError/RouteError.tsx
+++ b/src/components/RouteError/RouteError.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import { useEffect } from 'react';
 
 import styles from './RouteError.module.scss';
@@ -11,7 +12,7 @@ export interface RouteErrorProps {
 
 export function RouteError({ error, reset }: RouteErrorProps) {
   useEffect(() => {
-    console.error(error);
+    Sentry.captureException(error);
   }, [error]);
 
   return (


### PR DESCRIPTION
## Summary

- `RouteError` — replaces `console.error` with `Sentry.captureException`; used by all four route-level `error.tsx` files (`/`, `/fixtures`, `/table`, `/game-card`)
- `FixtureCardBoundary` — replaces `onError={console.error}` with `onError={(error) => Sentry.captureException(error)}`
- CI: `e2e` now only `needs: [build]`, so it runs in parallel with `lighthouse` instead of waiting for it to finish

## Why

The route-level and component-level boundaries were swallowing errors with `console.error` before they could bubble up to `global-error.tsx`, so nothing was reaching Sentry.

## Test plan

- [ ] Trigger a route-level error and confirm it appears in Sentry
- [ ] Confirm e2e and lighthouse jobs start simultaneously after build in CI