### PR TITLE
fix(proxy): exclude Sentry tunnel route from proxy matcher

### DIFF
--- a/e2e/metadata-routes.spec.ts
+++ b/e2e/metadata-routes.spec.ts
@@ -8,7 +8,7 @@ import { ICON_SIZES } from '../src/app/icon-sizes';
  * proxy does not rewrite them to a non-existent /[domain]/... route.
  *
  * Matcher exclusion list (src/proxy.ts):
- *   favicon.ico | icon | opengraph-image | sitemap.xml | robots.txt | manifest.webmanifest
+ *   favicon.ico | icon | opengraph-image | sitemap.xml | robots.txt | manifest.webmanifest | monitoring
  *
  * Icon coverage is driven by ICON_SIZES so it cannot drift from
  * src/app/manifest.ts, which emits one <link rel="icon"> per size.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,7 +54,8 @@ export const config = {
      * - _next/image (image optimization files)
      * - _vercel (Vercel Analytics / Speed Insights beacons)
      * - favicon.ico, sitemap.xml, robots.txt, manifest.webmanifest (metadata files)
+     * - monitoring (Sentry tunnel route — must not be rewritten to /[domain]/monitoring)
      */
-    '/((?!api|_next/static|_next/image|_vercel|favicon.ico|icon|opengraph-image|sitemap.xml|robots.txt|manifest.webmanifest).*)',
+    '/((?!api|_next/static|_next/image|_vercel|favicon.ico|icon|opengraph-image|sitemap.xml|robots.txt|manifest.webmanifest|monitoring).*)',
   ],
 };


### PR DESCRIPTION
## Summary

- Adds `monitoring` to the proxy matcher's negative-lookahead exclusion list in `src/proxy.ts`
- Without this, POST requests from the browser to `/monitoring` (the Sentry tunnel route) were being rewritten to `/${siteDomain}/monitoring` — a path with no handler — so Sentry events were silently dropped
- Updates the e2e `metadata-routes.spec.ts` comment to document the new exclusion

## Root cause

Next.js 16 renamed "middleware" to "proxy" (`src/proxy.ts`). The proxy runs on all paths not explicitly excluded. The `tunnelRoute: '/monitoring'` configured in `next.config.ts` was never excluded, so the proxy intercepted every Sentry tunnel POST before it could reach the Sentry-generated route handler.

## Test plan

- [ ] Verify Sentry receives events after deploy (check arsenal-america.sentry.io)
- [ ] Confirm `GET /monitoring` and other previously-excluded routes still return expected responses