### PR TITLE
fix(sentry): hardcode DSN instead of NEXT_PUBLIC_SENTRY_DSN env var

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: 'https://7baae90e741e2ddfbc9a504ddad08533@o4511266925969408.ingest.us.sentry.io/4511267016605696',
 
   tracesSampleRate: 0.5,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: 'https://7baae90e741e2ddfbc9a504ddad08533@o4511266925969408.ingest.us.sentry.io/4511267016605696',
 
   tracesSampleRate: 0.5,
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,7 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: 'https://7baae90e741e2ddfbc9a504ddad08533@o4511266925969408.ingest.us.sentry.io/4511267016605696',
 
   integrations: [Sentry.replayIntegration()],
 


### PR DESCRIPTION
## Summary

- Replaces `process.env.NEXT_PUBLIC_SENTRY_DSN` with the hardcoded DSN in all three Sentry config files (`sentry.server.config.ts`, `sentry.edge.config.ts`, `src/instrumentation-client.ts`)
- The DSN is a public project identifier — it ends up in the browser bundle in plain text regardless, so there is no security value in treating it as a secret
- The `NEXT_PUBLIC_*` env var approach was causing the DSN to be `undefined` at build time because the value was stored as an encrypted Vercel secret, which `vercel pull` cannot download during CI builds

## Test plan

- [ ] After deploy, verify `window.__SENTRY__?.['10.49.0']?.defaultCurrentScope?._client?._options?.dsn` is no longer `undefined`
- [ ] Confirm `Promise.reject(new Error("test"))` triggers a POST to `/monitoring?o=...&p=...` in the Network tab
- [ ] Confirm the event appears in https://arsenal-america.sentry.io/issues/