### PR TITLE
chore: add Sentry MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp/arsenal-america/app"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` scoping the Sentry MCP to the `arsenal-america/app` project
- Uses the hosted remote MCP at `mcp.sentry.dev` (no local binary or token required)
- Authentication is handled via OAuth on first use

## Test plan

- [ ] Start a new Claude Code session in this repo
- [ ] Run `/mcp` and confirm the Sentry server appears
- [ ] Authenticate via OAuth when prompted