### PR TITLE
refactor(sentry): consolidate config, tune sample rates, instrument server action

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -9,7 +9,7 @@ Sentry.init({
 
   integrations: [Sentry.replayIntegration()],
 
-  tracesSampleRate: 0.5,
+  tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,11 +2,11 @@ import * as Sentry from '@sentry/nextjs';
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    await import('../sentry.server.config');
+    await import('./sentry.server.config');
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {
-    await import('../sentry.edge.config');
+    await import('./sentry.edge.config');
   }
 }
 

--- a/src/lib/actions/loadDeferredFixture.ts
+++ b/src/lib/actions/loadDeferredFixture.ts
@@ -1,5 +1,8 @@
 'use server';
 
+import * as Sentry from '@sentry/nextjs';
+import { headers } from 'next/headers';
+
 import {
   getSettledFixtureById,
   getUnsettledFixtureById,
@@ -14,12 +17,18 @@ export async function loadDeferredFixture(
   id: number,
   settled: boolean,
 ): Promise<FixtureEntity> {
-  // Validate id against the static fixture index. fixture.id re-derives the
-  // value from a trusted server-side source, breaking the taint chain from
-  // the client-supplied parameter to the downstream fetch URL.
-  const fixture = fixtures.find((f) => f.id === id);
-  if (!fixture) throw new Error(`Unknown fixture id=${id}`);
-  return settled
-    ? getSettledFixtureById(fixture.id)
-    : getUnsettledFixtureById(fixture.id);
+  return Sentry.withServerActionInstrumentation(
+    'loadDeferredFixture',
+    { headers: await headers() },
+    async () => {
+      // Validate id against the static fixture index. fixture.id re-derives the
+      // value from a trusted server-side source, breaking the taint chain from
+      // the client-supplied parameter to the downstream fetch URL.
+      const fixture = fixtures.find((f) => f.id === id);
+      if (!fixture) throw new Error(`Unknown fixture id=${id}`);
+      return settled
+        ? getSettledFixtureById(fixture.id)
+        : getUnsettledFixtureById(fixture.id);
+    },
+  );
 }

--- a/src/sentry.edge.config.ts
+++ b/src/sentry.edge.config.ts
@@ -8,7 +8,7 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: 'https://7baae90e741e2ddfbc9a504ddad08533@o4511266925969408.ingest.us.sentry.io/4511267016605696',
 
-  tracesSampleRate: 0.5,
+  tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: 'https://7baae90e741e2ddfbc9a504ddad08533@o4511266925969408.ingest.us.sentry.io/4511267016605696',
 
-  tracesSampleRate: 0.5,
+  tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,


### PR DESCRIPTION
Closes #109

## Summary

- Move `sentry.{server,edge}.config.ts` from repo root into `src/` so all SDK init lives together (per Sentry Next.js docs); update import paths in `src/instrumentation.ts`.
- Lower `tracesSampleRate` from a fixed `0.5` to `process.env.NODE_ENV === 'development' ? 1.0 : 0.1` across client/server/edge to bring production sampling in line with docs and reduce trace volume.
- Wrap `loadDeferredFixture` (the only Server Action) with `Sentry.withServerActionInstrumentation()` so it surfaces as a named span and connects to client traces via headers.

Source maps upload is intentionally out of scope and tracked separately in #108 since our build runs in GitHub Actions, not on Vercel infrastructure.

## Test plan

- [ ] CI (biome / knip / typecheck / test / build) passes
- [ ] After deploy, throw a test error and confirm it arrives via the `/monitoring` tunnel
- [ ] Confirm logs and traces continue to flow from all three runtimes
- [ ] Trigger a deferred fixture load and verify the action shows up as a `loadDeferredFixture` server-action span in Sentry traces