### PR TITLE
feat(sentry): upload source maps from CI builds

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -36,10 +36,11 @@ Config: `lefthook.yml`
 
 ## Vercel Deployment
 
-The `build` job uses the Vercel CLI (`vercel` devDependency) with three required repository secrets:
+The `build` job uses the Vercel CLI (`vercel` devDependency) with these required repository secrets:
 - `VERCEL_TOKEN`
 - `VERCEL_ORG_ID`
 - `VERCEL_PROJECT_ID`
+- `SENTRY_AUTH_TOKEN` — consumed by the Sentry post-build hook during `vercel build` (which invokes Turbopack `next build`) to upload source maps to Sentry. Configured in `next.config.ts` via `withSentryConfig({ authToken: process.env.SENTRY_AUTH_TOKEN })`. Local builds work without it; upload is skipped silently when unset.
 
 Project IDs are sourced from `.vercel/project.json` (gitignored). Re-run `vercel link` locally to regenerate if needed.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       MONK_TOKEN: ${{ secrets.MONK_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: ./.github/actions/setup

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -14,6 +14,13 @@ const config: KnipConfig = {
     // Not installed as a project dependency — npx fetches it on demand.
     'sort-package-json',
   ],
+
+  ignoreDependencies: [
+    // Pinned in devDependencies so the version our build pipeline relies on is
+    // explicit, not transitive. Consumed at build time by @sentry/nextjs's
+    // Turbopack post-build hook to upload source maps; never imported directly.
+    '@sentry/cli',
+  ],
 };
 
 export default config;

--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,10 @@ export default withSentryConfig(nextConfig, {
 
   project: 'app',
 
+  // Auth token for source maps upload. Only present in CI; local builds skip
+  // the upload silently when this is undefined.
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@axe-core/playwright": "4.11.2",
     "@biomejs/biome": "2.4.13",
     "@playwright/test": "1.59.1",
+    "@sentry/cli": "^2.58.5",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4101,6 +4101,7 @@ __metadata:
     "@axe-core/playwright": "npm:4.11.2"
     "@biomejs/biome": "npm:2.4.13"
     "@playwright/test": "npm:1.59.1"
+    "@sentry/cli": "npm:^2.58.5"
     "@sentry/nextjs": "npm:^10"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"


### PR DESCRIPTION
Closes #108

## Summary

- Add \`authToken: process.env.SENTRY_AUTH_TOKEN\` to \`withSentryConfig\` in \`next.config.ts\`. The \`@sentry/nextjs\` Turbopack post-build hook uses this to upload source maps to Sentry after each CI build, so production stack traces resolve to original TypeScript instead of minified output.
- Expose \`SENTRY_AUTH_TOKEN\` to the GitHub Actions \`build\` job in \`.github/workflows/ci.yml\` so the token is present during \`yarn vercel build\`. Token already configured as a repo Actions + Dependabot secret.
- Pin \`@sentry/cli@^2.58.5\` as a direct devDependency (matches the version \`@sentry/bundler-plugin-core\` requires). The build pipeline depends on the CLI being installed; making that explicit prevents silent breakage if the upstream dependency tree shifts.
- Allowlist \`@sentry/cli\` in \`knip.config.ts\` since it's never imported directly — only consumed at build time by the Sentry SDK.
- Update \`.github/CLAUDE.md\` to list \`SENTRY_AUTH_TOKEN\` as a required \`build\` job secret.

## Why Turbopack matters here

Next.js 16 production builds run on Turbopack, not webpack. The legacy \"Sentry webpack plugin runs during compilation\" model does not apply. Per the [Sentry source maps docs](https://docs.sentry.io/platforms/javascript/guides/nextjs/sourcemaps/), under Turbopack the SDK uploads source maps in a **post-build hook** after \`next build\` finishes. We meet the version requirements (\`@sentry/nextjs@10.50.0\` ≥ 10.13, \`next@16.2.4\` ≥ 15.4.1).

## Out of scope

- Migration / removal of the existing \`webpack: { automaticVercelMonitors, treeshake }\` block in \`next.config.ts:59-71\`, which is webpack-only and likely no-ops under Turbopack — tracked in #111.
- Adding \`SENTRY_AUTH_TOKEN\` to Vercel project env vars. Not needed; the build runs on the GH Actions runner, not Vercel.

## Test plan

- [ ] CI build job logs show Sentry post-build output (source map upload, release creation, artifact counts) after \`yarn vercel build\` finishes
- [ ] After merge to \`main\`, confirm a new release in Sentry → Releases has source map artifacts attached
- [ ] Trigger a fresh production error and verify the Sentry issue's stack trace shows TypeScript source paths and readable function names rather than minified frames
- [ ] Local \`yarn build\` (without \`SENTRY_AUTH_TOKEN\` set) completes without errors and skips the upload silently