### PR TITLE
feat(sentry): align environment with GitHub deployment names

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -9,6 +9,11 @@ Sentry.init({
 
   integrations: [Sentry.replayIntegration()],
 
+  // Map to GitHub deployment environments (production, preview) instead of
+  // the SDK's default `vercel-*` auto-detection. Client only sees
+  // NEXT_PUBLIC_* env vars, so use the public mirror of VERCEL_ENV.
+  environment: process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV,
+
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Enable logs to be sent to Sentry

--- a/src/sentry.edge.config.ts
+++ b/src/sentry.edge.config.ts
@@ -8,6 +8,10 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: 'https://7baae90e741e2ddfbc9a504ddad08533@o4511266925969408.ingest.us.sentry.io/4511267016605696',
 
+  // Map to GitHub deployment environments (production, preview) instead of
+  // the SDK's default `vercel-*` auto-detection.
+  environment: process.env.VERCEL_ENV || process.env.NODE_ENV,
+
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Enable logs to be sent to Sentry

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -7,6 +7,10 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: 'https://7baae90e741e2ddfbc9a504ddad08533@o4511266925969408.ingest.us.sentry.io/4511267016605696',
 
+  // Map to GitHub deployment environments (production, preview) instead of
+  // the SDK's default `vercel-*` auto-detection.
+  environment: process.env.VERCEL_ENV || process.env.NODE_ENV,
+
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Enable logs to be sent to Sentry


### PR DESCRIPTION
Closes #114

## Summary

Set \`environment\` explicitly in all three Sentry init files so events tag with values that match our GitHub deployment environments (\`production\`, \`preview\`) instead of the SDK's default \`vercel-*\` auto-detection.

Mapping:

| Runtime | Before | After |
|---|---|---|
| Vercel production deploy | \`vercel-production\` | \`production\` |
| Vercel preview deploy | \`vercel-preview\` | \`preview\` |
| Local \`next dev\` | \`development\` | \`development\` |

## Notes

- Server/edge use \`process.env.VERCEL_ENV\`; client uses \`process.env.NEXT_PUBLIC_VERCEL_ENV\` since the bundle only sees \`NEXT_PUBLIC_*\` env vars at runtime.
- Existing \`vercel-*\` events already in Sentry stay attached to those legacy environments — they just stop accumulating new events. Legacy buckets can be left to age out or renamed via the Sentry UI.

## Test plan

- [ ] CI green
- [ ] After preview deploy: confirm new events arrive under \`preview\` (not \`vercel-preview\`)
- [ ] After merge to main + production deploy: confirm new events arrive under \`production\` (not \`vercel-production\`)
- [ ] \`yarn dev\` locally surfaces events under \`development\` if any are emitted